### PR TITLE
Port cmake scripts to linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Part of Beast
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.2)
 
 project (Beast)
 
@@ -9,6 +9,17 @@ set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 if (WIN32)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /wd4100 /D_SCL_SECURE_NO_WARNINGS=1 /D_CRT_SECURE_NO_WARNINGS=1")
 else()
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_MULTITHREADED ON)
+    find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
+    include_directories(${Boost_INCLUDE_DIRS})
+    link_directories(${Boost_LIBRARY_DIR})
+
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads)
+
+    set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -g -std=c++11 -Wall -Wno-unused-variable")
 endif()
 
 message ("cxx Flags: " ${CMAKE_CXX_FLAGS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,22 +9,42 @@ add_executable (http-crawl
     urls_large_data.cpp
 )
 
+if (NOT WIN32)
+    target_link_libraries(http-crawl ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 add_executable (http-server
     ${BEAST_INCLUDES}
     http_server.cpp
 )
+
+if (NOT WIN32)
+    target_link_libraries(http-server ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 add_executable (http-example
     ${BEAST_INCLUDES}
     http_example.cpp
 )
 
+if (NOT WIN32)
+    target_link_libraries(http-example ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 add_executable (websocket-echo
     ${BEAST_INCLUDES}
     websocket_echo.cpp
 )
 
+if (NOT WIN32)
+    target_link_libraries(websocket-echo ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 add_executable (websocket-example
     ${BEAST_INCLUDES}
     websocket_example.cpp
 )
+
+if (NOT WIN32)
+    target_link_libraries(websocket-example ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,10 @@ add_executable (core-tests
     ${CORE_TESTS_SRCS}
 )
 
+if (NOT WIN32)
+    target_link_libraries(core-tests ${Boost_LIBRARIES})
+endif()
+
 set(HTTP_TESTS_SRCS
     main.cpp
     http/basic_headers.cpp
@@ -55,6 +59,10 @@ add_executable (http-tests
     ${HTTP_TESTS_SRCS}
 )
 
+if (NOT WIN32)
+    target_link_libraries(http-tests ${Boost_LIBRARIES})
+endif()
+
 set(WEBSOCKET_TESTS_SRCS
     main.cpp
     websocket/error.cpp
@@ -70,6 +78,10 @@ add_executable (websocket-tests
     ${WEBSOCKET_TESTS_SRCS}
 )
 
+if (NOT WIN32)
+    target_link_libraries(websocket-tests ${Boost_LIBRARIES})
+endif()
+
 set(PARSER_BENCH_SRCS
     main.cpp
     http/nodejs_parser.cpp
@@ -80,3 +92,7 @@ add_executable (parser-bench
     ${BEAST_INCLUDES}
     ${PARSER_BENCH_SRCS}
 )
+
+if (NOT WIN32)
+    target_link_libraries(parser-bench ${Boost_LIBRARIES})
+endif()


### PR DESCRIPTION
Modified root CMakeLists.txt to find the boost libraries. Every executable will be linked against the boost libs. I also downgraded the required CMake to 3.2 (that's what's on my system).

CXX_FLAGS should be the same as those in Jamroot.