### PR TITLE
Do not run coverage until all jobs have finished

### DIFF
--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -19,10 +19,25 @@ function run_tests_with_gdb {
   for x in bin/**/*-tests; do scripts/run-with-gdb.sh "$x"; done
 }
 
+function run_tests {
+    for x in bin/**/*-tests; do "$x"; done
+}
+
+num_procs=1
+if [[ $(uname) == "Darwin" ]]; then
+    num_procs=$(sysctl -n hw.ncpu)
+elif [[ $(uname -s) == "Linux" ]]; then
+    num_procs=$(lscpu -p | grep -v '^#' | sort -u -t, -k 2,4 | wc -l) # physical cores
+    virt_num_procs=$(nproc) # CircleCI returns 32 phys procs, but 1 virt proc
+    if (("$virt_num_procs" < "$num_procs")); then
+        num_procs=$virt_num_procs
+    fi
+fi
+
 function build_beast {
   $BOOST_ROOT/bjam toolset=$CC \
                variant=$VARIANT \
-               address-model=$ADDRESS_MODEL
+               address-model=$ADDRESS_MODEL -j${num_procs}
 }
 
 ##################################### BUILD ####################################
@@ -38,11 +53,11 @@ if [[ $VARIANT == "coverage" ]]; then
   lcov --no-external -c -i -d . -o baseline.info > /dev/null
 
   # Perform test
-  run_tests_with_gdb
+  run_tests
 
   # Run autobahn tests
-  export SERVER=`find . -name "websocket-echo"`
-  nohup scripts/run-with-gdb.sh $SERVER&
+  export SERVER=$(find . -name "websocket-echo")
+  nohup $SERVER&
 
   # We need to wait a while so wstest can connect!
   sleep 5
@@ -52,10 +67,10 @@ if [[ $VARIANT == "coverage" ]]; then
   cat nohup.out
   rm nohup.out
   jobs
+  sleep 5
   # Kill it gracefully
   kill -INT %1
-  sleep 1
-  kill -INT %1 || echo "Dead already"
+  wait
 
   # Create test coverage data file
   lcov --no-external -c -d . -o testrun.info > /dev/null


### PR DESCRIPTION
Sometimes lcov would report negative counts. This may be related to lcov
running while the job it was collecting counts for was also running.
This patch makes two changes: Do not run the coverage build under
gdb, and wait for all jobs to finish before running lcov.

@ximinez @sublimator 