### PR TITLE
Fix rfc2616 Section 4.2 compliance:

### DIFF
--- a/test/http/basic_headers.cpp
+++ b/test/http/basic_headers.cpp
@@ -63,9 +63,23 @@ public:
     void testRFC2616()
     {
         bh h;
+        h.insert("a", "w");
         h.insert("a", "x");
-        h.insert("a", "y");
-        expect(h["a"] == "x,y");
+        h.insert("aa", "y");
+        h.insert("b", "z");
+        expect(h.count("a") == 2);
+    }
+
+    void testErase()
+    {
+        bh h;
+        h.insert("a", "w");
+        h.insert("a", "x");
+        h.insert("aa", "y");
+        h.insert("b", "z");
+        expect(h.size() == 4);
+        h.erase("a");
+        expect(h.size() == 2);
     }
 
     void run() override


### PR DESCRIPTION
`basic_headers` no longer combines fields with the same name by appending a comma and concatenating the two values together. This was breaking certain header fields which expect each value to be distinct, such as the "Set-Cookie" header.

Now the container behaves more like a multi set with respect to insertion of multiple values with the same field name. Additional member functions are provided to provide extra functionality.

Reviewers: @HowardHinnant @scottschurr @willwray