### PR TITLE
Fixes for some compiler warnings

### DIFF
--- a/include/beast/websocket/detail/frame.hpp
+++ b/include/beast/websocket/detail/frame.hpp
@@ -110,7 +110,7 @@ is_valid(close_code::value code)
     if(v >= 1016 && v <= 2999)
         return false;
     // not used
-    if(v >= 0 && v <= 999)
+    if(v <= 999)
         return false;
     return true;
 }

--- a/include/beast/websocket/teardown.hpp
+++ b/include/beast/websocket/teardown.hpp
@@ -51,7 +51,7 @@ teardown(teardown_tag, Socket& socket, error_code& ec)
 */
     static_assert(sizeof(Socket)==-1,
         "Unknown Socket type in teardown.");
-};
+}
 
 /** Start tearing down a connection.
 


### PR DESCRIPTION
Hi there!

I've started using Beast in my own project and while compiling I noticed a few compiler warnings that were easy to fix. These commits fix the following warnings:

```
include/beast/websocket/detail/frame.hpp:113:10: warning: comparison is always true due to limited range of data type [-Wtype-limits]
     if(v >= 0 && v <= 999)
        ~~^~~~

include/beast/websocket/teardown.hpp:54:2: warning: extra ‘;’ [-Wpedantic]
 };
```
Please let me know what you think.

And of course: thanks for all the great work so far, I love how Beast seamlessly integrates in my Asio-based application! :smile: 