### PR TITLE
Fix unused parameter warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
     find_package(Threads)
 
     set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wpedantic")
+      "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wpedantic")
 endif()
 
 if (APPLE AND NOT DEFINED ENV{OPENSSL_ROOT_DIR})

--- a/examples/http_sync_server.hpp
+++ b/examples/http_sync_server.hpp
@@ -11,6 +11,8 @@
 #include "file_body.hpp"
 #include "mime_type.hpp"
 
+#include <beast/http.hpp>
+#include <beast/core/placeholders.hpp>
 #include <beast/core/streambuf.hpp>
 #include <boost/asio.hpp>
 #include <cstdint>
@@ -19,6 +21,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <utility>
 
 #include <iostream>

--- a/extras/beast/test/string_stream.hpp
+++ b/extras/beast/test/string_stream.hpp
@@ -8,6 +8,7 @@
 #ifndef BEAST_TEST_STRING_STREAM_HPP
 #define BEAST_TEST_STRING_STREAM_HPP
 
+#include <beast/core/async_completion.hpp>
 #include <beast/core/bind_handler.hpp>
 #include <beast/core/error.hpp>
 #include <boost/asio/buffer.hpp>

--- a/include/beast/core/detail/ignore_unused.hpp
+++ b/include/beast/core/detail/ignore_unused.hpp
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2013-2016 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BEAST_DETAIL_IGNORE_UNUSED_HPP
+#define BEAST_DETAIL_IGNORE_UNUSED_HPP
+
+namespace beast {
+namespace detail {
+
+template <typename... Ts>
+inline void ignore_unused(Ts const& ...)
+{}
+
+template <typename... Ts>
+inline void ignore_unused()
+{}
+
+} // namespace detail
+} // namespace boost
+
+#endif

--- a/include/beast/core/impl/basic_streambuf.ipp
+++ b/include/beast/core/impl/basic_streambuf.ipp
@@ -9,6 +9,7 @@
 #define BEAST_IMPL_BASIC_STREAMBUF_IPP
 
 #include <beast/core/detail/write_dynabuf.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/assert.hpp>
 #include <algorithm>
 #include <exception>
@@ -786,6 +787,7 @@ void
 basic_streambuf<Allocator>::
 copy_assign(basic_streambuf const& other, std::false_type)
 {
+    beast::detail::ignore_unused(other);
 }
 
 template<class Allocator>

--- a/include/beast/http/basic_dynabuf_body.hpp
+++ b/include/beast/http/basic_dynabuf_body.hpp
@@ -9,6 +9,7 @@
 #define BEAST_HTTP_BASIC_DYNABUF_BODY_HPP
 
 #include <beast/http/body_type.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/asio/buffer.hpp>
 
 namespace beast {
@@ -71,6 +72,7 @@ private:
         void
         init(error_code& ec)
         {
+            beast::detail::ignore_unused(ec);
         }
 
         std::uint64_t

--- a/include/beast/http/empty_body.hpp
+++ b/include/beast/http/empty_body.hpp
@@ -9,6 +9,7 @@
 #define BEAST_HTTP_EMPTY_BODY_HPP
 
 #include <beast/http/body_type.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/asio/buffer.hpp>
 #include <memory>
 #include <string>
@@ -42,11 +43,13 @@ private:
         explicit
         writer(message<isRequest, empty_body, Headers> const& m)
         {
+            beast::detail::ignore_unused(m);
         }
 
         void
         init(error_code& ec)
         {
+            beast::detail::ignore_unused(ec);
         }
 
         std::uint64_t

--- a/include/beast/http/impl/message_v1.ipp
+++ b/include/beast/http/impl/message_v1.ipp
@@ -11,6 +11,7 @@
 #include <beast/core/error.hpp>
 #include <beast/http/rfc7230.hpp>
 #include <beast/core/detail/ci_char_traits.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <beast/http/detail/has_content_length.hpp>
 #include <boost/optional.hpp>
 #include <stdexcept>
@@ -58,6 +59,7 @@ void
 prepare_options(prepare_info& pi,
     message_v1<isRequest, Body, Headers>& msg)
 {
+    beast::detail::ignore_unused(pi, msg);
 }
 
 template<bool isRequest, class Body, class Headers>
@@ -66,6 +68,7 @@ prepare_option(prepare_info& pi,
     message_v1<isRequest, Body, Headers>& msg,
         connection value)
 {
+    beast::detail::ignore_unused(msg);
     pi.connection_value = value;
 }
 
@@ -103,6 +106,7 @@ prepare_content_length(prepare_info& pi,
     message_v1<isRequest, Body, Headers> const& msg,
         std::false_type)
 {
+    beast::detail::ignore_unused(msg);
     pi.content_length = boost::none;
 }
 

--- a/include/beast/http/parser_v1.hpp
+++ b/include/beast/http/parser_v1.hpp
@@ -12,6 +12,7 @@
 #include <beast/http/concepts.hpp>
 #include <beast/http/message_v1.hpp>
 #include <beast/core/error.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/assert.hpp>
 #include <functional>
 #include <string>
@@ -243,12 +244,14 @@ private:
 
     void on_request(error_code& ec)
     {
+        beast::detail::ignore_unused(ec);
         set(std::integral_constant<
             bool, isRequest>{});
     }
 
     void on_response(error_code& ec)
     {
+        beast::detail::ignore_unused(ec);
         set(std::integral_constant<
             bool, isRequest>{});
     }

--- a/include/beast/http/string_body.hpp
+++ b/include/beast/http/string_body.hpp
@@ -9,6 +9,7 @@
 #define BEAST_HTTP_STRING_BODY_HPP
 
 #include <beast/http/body_type.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/asio/buffer.hpp>
 #include <memory>
 #include <string>
@@ -71,6 +72,7 @@ private:
         void
         init(error_code& ec)
         {
+            beast::detail::ignore_unused(ec);
         }
 
         std::uint64_t

--- a/include/beast/websocket/detail/hybi13.hpp
+++ b/include/beast/websocket/detail/hybi13.hpp
@@ -11,6 +11,7 @@
 #include <beast/core/detail/base64.hpp>
 #include <beast/core/detail/sha1.hpp>
 #include <boost/utility/string_ref.hpp>
+#include <array>
 #include <cstdint>
 #include <string>
 #include <type_traits>

--- a/include/beast/websocket/impl/accept_op.ipp
+++ b/include/beast/websocket/impl/accept_op.ipp
@@ -14,6 +14,7 @@
 #include <beast/http/read.hpp>
 #include <beast/core/handler_alloc.hpp>
 #include <beast/core/prepare_buffers.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/assert.hpp>
 #include <memory>
 #include <type_traits>
@@ -117,6 +118,7 @@ stream<NextLayer>::accept_op<Handler>::
 operator()(error_code const& ec,
     std::size_t bytes_transferred, bool again)
 {
+    beast::detail::ignore_unused(bytes_transferred);
     auto& d = *d_;
     d.cont = d.cont || again;
     while(! ec && d.state != 99)

--- a/test/http/message_fuzz.hpp
+++ b/test/http/message_fuzz.hpp
@@ -10,6 +10,7 @@
 
 #include <beast/core/write_dynabuf.hpp>
 #include <beast/http/detail/basic_parser_v1.hpp>
+#include <beast/http/detail/rfc7230.hpp>
 #include <cstdint>
 #include <random>
 #include <string>

--- a/test/http/nodejs_parser.hpp
+++ b/test/http/nodejs_parser.hpp
@@ -14,6 +14,7 @@
 #include <beast/http/rfc7230.hpp>
 #include <beast/core/buffer_concepts.hpp>
 #include <beast/core/error.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/system/error_code.hpp>
 #include <cstdint>
@@ -798,6 +799,7 @@ private:
         int major, int minor, bool keep_alive, bool upgrade,
             std::true_type)
     {
+        beast::detail::ignore_unused(keep_alive, upgrade);
         m_.method = detail::method_to_string(method);
         m_.url = url;
         m_.version = major * 10 + minor;
@@ -826,6 +828,7 @@ private:
         int major, int minor, bool keep_alive, bool upgrade,
             std::true_type)
     {
+        beast::detail::ignore_unused(keep_alive, upgrade);
         m_.status = status;
         m_.reason = reason;
         m_.version = major * 10 + minor;

--- a/test/http/write.cpp
+++ b/test/http/write.cpp
@@ -16,6 +16,7 @@
 #include <beast/core/error.hpp>
 #include <beast/core/streambuf.hpp>
 #include <beast/core/to_string.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <beast/test/fail_stream.hpp>
 #include <beast/test/yield_to.hpp>
 #include <beast/unit_test/suite.hpp>
@@ -66,6 +67,7 @@ public:
         write_some(
             ConstBufferSequence const& buffers, error_code& ec)
         {
+            beast::detail::ignore_unused(ec);
             auto const n = buffer_size(buffers);
             using boost::asio::buffer_size;
             using boost::asio::buffer_cast;
@@ -112,6 +114,7 @@ public:
             void
             init(error_code& ec)
             {
+                beast::detail::ignore_unused(ec);
             }
 
             template<class Write>

--- a/test/websocket/stream.cpp
+++ b/test/websocket/stream.cpp
@@ -13,6 +13,7 @@
 
 #include <beast/core/streambuf.hpp>
 #include <beast/core/to_string.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <beast/test/fail_stream.hpp>
 #include <beast/test/string_stream.hpp>
 #include <beast/test/yield_to.hpp>
@@ -492,6 +493,7 @@ public:
 
     void testClose(endpoint_type const& ep, yield_context do_yield)
     {
+        beast::detail::ignore_unused(do_yield);
         {
             // payload length 1
             con c(ep, ios_);

--- a/test/websocket/websocket_sync_echo_server.hpp
+++ b/test/websocket/websocket_sync_echo_server.hpp
@@ -8,7 +8,9 @@
 #ifndef BEAST_WEBSOCKET_SYNC_ECHO_PEER_H_INCLUDED
 #define BEAST_WEBSOCKET_SYNC_ECHO_PEER_H_INCLUDED
 
+#include <beast/core/placeholders.hpp>
 #include <beast/core/streambuf.hpp>
+#include <beast/core/detail/ignore_unused.hpp>
 #include <beast/websocket.hpp>
 #include <boost/optional.hpp>
 #include <functional>
@@ -40,6 +42,7 @@ public:
         : sock_(ios_)
         , acceptor_(ios_)
     {
+        beast::detail::ignore_unused(server);
         error_code ec;
         acceptor_.open(ep.protocol(), ec);
         maybe_throw(ec, "open");


### PR DESCRIPTION
Fixes warnings from gcc 5.4 (ubuntu xenial) with -Wall -Wextra.