### PR TITLE
Improve websocket example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ int main()
     beast::websocket::opcode op;
     ws.read(op, sb);
     ws.close(beast::websocket::close_code::normal);
-    std::cout << to_string(sb.data()) << "\n";
+    std::cout << beast::to_string(sb.data()) << "\n";
 }
 ```
 

--- a/examples/websocket_example.cpp
+++ b/examples/websocket_example.cpp
@@ -31,5 +31,5 @@ int main()
     beast::websocket::opcode op;
     ws.read(op, sb);
     ws.close(beast::websocket::close_code::normal);
-    std::cout << to_string(sb.data()) << "\n";
+    std::cout << beast::to_string(sb.data()) << "\n";
 }


### PR DESCRIPTION
change call: to_string --> beast::to_string

My IDE at least was complaining about a plain `to_string` in the code, even though the compilation works fine. I don't understand C++ well enough yet to understand how the compiler manages to resolve `to_string` as `beast::to_string` all by itself, but at least my IDE (CLion) agrees with me (wrongly), so it might have merit to clean up that part of the sample!