### PR TITLE
Improve websocket example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Relax ForwardIterator requirements in FieldSequence
 * Fix websocket failure testing
 * Refine Writer concept and fix exemplar in documentation
+* Improve websocket example
 
 API Changes:
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ int main()
     beast::websocket::opcode op;
     ws.read(op, sb);
     ws.close(beast::websocket::close_code::normal);
-    std::cout << to_string(sb.data()) << "\n";
+    std::cout << beast::to_string(sb.data()) << "\n";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ int main()
     // WebSocket connect and send message using beast
     beast::websocket::stream<boost::asio::ip::tcp::socket&> ws{sock};
     ws.handshake(host, "/");
-    ws.write(boost::asio::buffer("Hello, world!"));
+    ws.write(boost::asio::buffer(std::string("Hello, world!")));
 
     // Receive WebSocket message, print and close using beast
     beast::streambuf sb;

--- a/examples/websocket_example.cpp
+++ b/examples/websocket_example.cpp
@@ -31,5 +31,5 @@ int main()
     beast::websocket::opcode op;
     ws.read(op, sb);
     ws.close(beast::websocket::close_code::normal);
-    std::cout << to_string(sb.data()) << "\n";
+    std::cout << beast::to_string(sb.data()) << "\n";
 }

--- a/examples/websocket_example.cpp
+++ b/examples/websocket_example.cpp
@@ -24,7 +24,7 @@ int main()
     // WebSocket connect and send message using beast
     beast::websocket::stream<boost::asio::ip::tcp::socket&> ws{sock};
     ws.handshake(host, "/");
-    ws.write(boost::asio::buffer("Hello, world!"));
+    ws.write(boost::asio::buffer(std::string("Hello, world!")));
 
     // Receive WebSocket message, print and close using beast
     beast::streambuf sb;


### PR DESCRIPTION
This one I'm not expecting to be merged, but I wanted to bring this up anyway:

Again, using CLion IDE, the IDE seems to get confused for whatever reason about the call to

`boost::asio::buffer("Hello, world!")`

and at least when we're talking about an example it might be a good thing to not trigger any error highlighting in popular IDE choices when we're expecting relative newcomers to jump in and try to load up and run a sample.

I'm not comfortable enough with C++ to tell if wrapping the `const char*` in a `std::string()` is adding any overhead (and as such might teach someone out there looking at this code a bad trick), and in any case more code is worse if less code will produce the same result, so I'm not sure if this should be merged.

Also, speaking of equal results: I noticed that while the compiler (clang++-3.8) compiles the example just fine as is, I'm getting a different output from running the program with vs without the `std::string()` wrapping -- some null character or so seems to be attached in the output in the example as is, while I'm getting no funny output in the wrapped version.

Again, I'm a relative newcomer (actually "back-comer") to C++ development, so maybe this is a complete non-issue to every normal C++ dev out there.

Cheers,
Denis