### PR TITLE
1.0.0-b28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.0-b28
+
+* Split out and rename test stream classes
+
+--------------------------------------------------------------------------------
+
 1.0.0-b27
 
 * Tidy up tests and docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 1.0.0-b28
 
 * Split out and rename test stream classes
+* Restyle async result constructions
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Split out and rename test stream classes
 * Restyle async result constructions
+* Fix HTTP split parse edge case
 
 --------------------------------------------------------------------------------
 

--- a/extras/beast/test/fail_stream.hpp
+++ b/extras/beast/test/fail_stream.hpp
@@ -113,7 +113,7 @@ public:
         {
             async_completion<
                 ReadHandler, void(error_code, std::size_t)
-                    > completion(handler);
+                    > completion{handler};
             next_layer_.get_io_service().post(
                 bind_handler(completion.handler, ec, 0));
             return completion.result.get();
@@ -150,7 +150,7 @@ public:
         {
             async_completion<
                 WriteHandler, void(error_code, std::size_t)
-                    > completion(handler);
+                    > completion{handler};
             next_layer_.get_io_service().post(
                 bind_handler(completion.handler, ec, 0));
             return completion.result.get();

--- a/extras/beast/test/string_istream.hpp
+++ b/extras/beast/test/string_istream.hpp
@@ -5,12 +5,13 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifndef BEAST_TEST_STRING_STREAM_HPP
-#define BEAST_TEST_STRING_STREAM_HPP
+#ifndef BEAST_TEST_STRING_ISTREAM_HPP
+#define BEAST_TEST_STRING_ISTREAM_HPP
 
 #include <beast/core/async_completion.hpp>
 #include <beast/core/bind_handler.hpp>
 #include <beast/core/error.hpp>
+#include <beast/core/prepare_buffer.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/io_service.hpp>
 #include <string>
@@ -24,16 +25,21 @@ namespace test {
     discarded, and when data is read it comes from a string provided
     at construction.
 */
-class string_stream
+class string_istream
 {
     std::string s_;
+    boost::asio::const_buffer cb_;
     boost::asio::io_service& ios_;
+    std::size_t read_max_;
 
 public:
-    string_stream(boost::asio::io_service& ios,
-            std::string s)
+    string_istream(boost::asio::io_service& ios,
+            std::string s, std::size_t read_max =
+                (std::numeric_limits<std::size_t>::max)())
         : s_(std::move(s))
+        , cb_(boost::asio::buffer(s_))
         , ios_(ios)
+        , read_max_(read_max)
     {
     }
 
@@ -60,9 +66,9 @@ public:
         error_code& ec)
     {
         auto const n = boost::asio::buffer_copy(
-            buffers, boost::asio::buffer(s_));
+            buffers, prepare_buffer(read_max_, cb_));
         if(n > 0)
-            s_.erase(0, n);
+            cb_ = cb_ + n;
         else
             ec = boost::asio::error::eof;
         return n;

--- a/extras/beast/test/string_istream.hpp
+++ b/extras/beast/test/string_istream.hpp
@@ -88,7 +88,7 @@ public:
         else
             ec = boost::asio::error::eof;
         async_completion<ReadHandler,
-            void(error_code, std::size_t)> completion(handler);
+            void(error_code, std::size_t)> completion{handler};
         ios_.post(bind_handler(
             completion.handler, ec, n));
         return completion.result.get();
@@ -120,7 +120,7 @@ public:
         WriteHandler&& handler)
     {
         async_completion<WriteHandler,
-            void(error_code, std::size_t)> completion(handler);
+            void(error_code, std::size_t)> completion{handler};
         ios_.post(bind_handler(completion.handler,
             error_code{}, boost::asio::buffer_size(buffers)));
         return completion.result.get();

--- a/extras/beast/test/string_ostream.hpp
+++ b/extras/beast/test/string_ostream.hpp
@@ -105,7 +105,7 @@ public:
         auto const bytes_transferred = write_some(buffers, ec);
         async_completion<
             WriteHandler, void(error_code, std::size_t)
-                > completion(handler);
+                > completion{handler};
         get_io_service().post(
             bind_handler(completion.handler, ec, bytes_transferred));
         return completion.result.get();

--- a/extras/beast/test/string_ostream.hpp
+++ b/extras/beast/test/string_ostream.hpp
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BEAST_TEST_STRING_OSTREAM_HPP
+#define BEAST_TEST_STRING_OSTREAM_HPP
+
+#include <beast/core/async_completion.hpp>
+#include <beast/core/bind_handler.hpp>
+#include <beast/core/error.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <string>
+
+namespace beast {
+namespace test {
+
+class string_ostream
+{
+    boost::asio::io_service& ios_;
+
+public:
+    std::string str;
+
+    explicit
+    string_ostream(boost::asio::io_service& ios)
+        : ios_(ios)
+    {
+    }
+
+    boost::asio::io_service&
+    get_io_service()
+    {
+        return ios_;
+    }
+
+    template<class MutableBufferSequence>
+    std::size_t
+    read_some(MutableBufferSequence const& buffers)
+    {
+        error_code ec;
+        auto const n = read_some(buffers, ec);
+        if(ec)
+            throw system_error{ec};
+        return n;
+    }
+
+    template<class MutableBufferSequence>
+    std::size_t
+    read_some(MutableBufferSequence const& buffers,
+        error_code& ec)
+    {
+        return 0;
+    }
+
+    template<class MutableBufferSequence, class ReadHandler>
+    typename async_completion<ReadHandler,
+        void(error_code, std::size_t)>::result_type
+    async_read_some(MutableBufferSequence const& buffers,
+        ReadHandler&& handler)
+    {
+        async_completion<ReadHandler,
+            void(error_code, std::size_t)> completion{handler};
+        ios_.post(bind_handler(completion.handler,
+            error_code{}, 0));
+        return completion.result.get();
+    }
+
+    template<class ConstBufferSequence>
+    std::size_t
+    write_some(ConstBufferSequence const& buffers)
+    {
+        error_code ec;
+        auto const n = write_some(buffers, ec);
+        if(ec)
+            throw system_error{ec};
+        return n;
+    }
+
+    template<class ConstBufferSequence>
+    std::size_t
+    write_some(
+        ConstBufferSequence const& buffers, error_code&)
+    {
+        auto const n = buffer_size(buffers);
+        using boost::asio::buffer_size;
+        using boost::asio::buffer_cast;
+        str.reserve(str.size() + n);
+        for(auto const& buffer : buffers)
+            str.append(buffer_cast<char const*>(buffer),
+                buffer_size(buffer));
+        return n;
+    }
+
+    template<class ConstBufferSequence, class WriteHandler>
+    typename async_completion<
+        WriteHandler, void(error_code)>::result_type
+    async_write_some(ConstBufferSequence const& buffers,
+        WriteHandler&& handler)
+    {
+        error_code ec;
+        auto const bytes_transferred = write_some(buffers, ec);
+        async_completion<
+            WriteHandler, void(error_code, std::size_t)
+                > completion(handler);
+        get_io_service().post(
+            bind_handler(completion.handler, ec, bytes_transferred));
+        return completion.result.get();
+    }
+};
+
+} // test
+} // beast
+
+#endif

--- a/include/beast/core/async_completion.hpp
+++ b/include/beast/core/async_completion.hpp
@@ -38,7 +38,7 @@ namespace beast {
     async_initfn(..., CompletionHandler&& handler)
     {
         async_completion<CompletionHandler,
-            void(error_code)> completion(handler);
+            void(error_code)> completion{handler};
         ...
         return completion.result.get();
     }

--- a/include/beast/core/impl/dynabuf_readstream.ipp
+++ b/include/beast/core/impl/dynabuf_readstream.ipp
@@ -242,7 +242,7 @@ async_read_some(
             "MutableBufferSequence requirements not met");
     beast::async_completion<
         ReadHandler, void(error_code, std::size_t)
-            > completion(handler);
+            > completion{handler};
     read_some_op<MutableBufferSequence,
         decltype(completion.handler)>{
             completion.handler, *this, buffers};

--- a/include/beast/http/basic_parser_v1.hpp
+++ b/include/beast/http/basic_parser_v1.hpp
@@ -35,7 +35,8 @@ enum parse_flag
     trailing              =  16,
     upgrade               =  32,
     skipbody              =  64,
-    contentlength         = 128
+    contentlength         = 128,
+    paused                = 256
 };
 
 /** Body maximum size option.
@@ -280,12 +281,12 @@ private:
     std::uint64_t content_length_;
     pmf_t cb_;
     state s_              : 8;
-    unsigned flags_       : 8;
     unsigned fs_          : 8;
     unsigned pos_         : 8; // position in field state
     unsigned http_major_  : 16;
     unsigned http_minor_  : 16;
     unsigned status_code_ : 16;
+    unsigned flags_       : 9;
     bool upgrade_         : 1; // true if parser exited for upgrade
 
 public:
@@ -434,7 +435,7 @@ public:
         return
             s_ == s_restart ||
             s_ == s_closed_complete ||
-            s_ == s_body_pause;
+            (flags_ & parse_flag::paused);
     }
 
     /** Write a sequence of buffers to the parser.

--- a/include/beast/http/impl/basic_parser_v1.ipp
+++ b/include/beast/http/impl/basic_parser_v1.ipp
@@ -45,6 +45,7 @@ namespace http {
 template<bool isRequest, class Derived>
 basic_parser_v1<isRequest, Derived>::
 basic_parser_v1()
+    : flags_(0)
 {
     init();
 }
@@ -61,12 +62,12 @@ basic_parser_v1(basic_parser_v1<
     , content_length_(other.content_length_)
     , cb_(nullptr)
     , s_(other.s_)
-    , flags_(other.flags_)
     , fs_(other.fs_)
     , pos_(other.pos_)
     , http_major_(other.http_major_)
     , http_minor_(other.http_minor_)
     , status_code_(other.status_code_)
+    , flags_(other.flags_)
     , upgrade_(other.upgrade_)
 {
     BOOST_ASSERT(! other.cb_);
@@ -88,13 +89,14 @@ operator=(basic_parser_v1<
     content_length_ = other.content_length_;
     cb_ = nullptr;
     s_ = other.s_;
-    flags_ = other.flags_;
     fs_ = other.fs_;
     pos_ = other.pos_;
     http_major_ = other.http_major_;
     http_minor_ = other.http_minor_;
     status_code_ = other.status_code_;
+    flags_ = other.flags_;
     upgrade_ = other.upgrade_;
+    flags_ &= ~parse_flag::paused;
     return *this;
 }
 
@@ -966,6 +968,7 @@ write(boost::asio::const_buffer const& buffer, error_code& ec)
             case body_what::pause:
                 ++p;
                 s_ = s_body_pause;
+                flags_ |= parse_flag::paused;
                 return used();
             }
             s_ = s_headers_done;

--- a/include/beast/http/impl/parse.ipp
+++ b/include/beast/http/impl/parse.ipp
@@ -289,7 +289,7 @@ async_parse(AsyncReadStream& stream,
     static_assert(is_Parser<Parser>::value,
         "Parser requirements not met");
     beast::async_completion<ReadHandler,
-        void(error_code)> completion(handler);
+        void(error_code)> completion{handler};
     detail::parse_op<AsyncReadStream, DynamicBuffer,
         Parser, decltype(completion.handler)>{
             completion.handler, stream, dynabuf, parser};

--- a/include/beast/http/impl/read.ipp
+++ b/include/beast/http/impl/read.ipp
@@ -183,7 +183,7 @@ async_read(AsyncReadStream& stream, DynamicBuffer& dynabuf,
     static_assert(is_DynamicBuffer<DynamicBuffer>::value,
         "DynamicBuffer requirements not met");
     beast::async_completion<ReadHandler,
-        void(error_code)> completion(handler);
+        void(error_code)> completion{handler};
     detail::read_header_op<AsyncReadStream, DynamicBuffer,
         isRequest, Fields, decltype(
             completion.handler)>{completion.handler,
@@ -375,7 +375,7 @@ async_read(AsyncReadStream& stream, DynamicBuffer& dynabuf,
         message<isRequest, Body, Fields>>::value,
             "Reader requirements not met");
     beast::async_completion<ReadHandler,
-        void(error_code)> completion(handler);
+        void(error_code)> completion{handler};
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Body, Fields, decltype(
             completion.handler)>{completion.handler,

--- a/include/beast/http/impl/write.ipp
+++ b/include/beast/http/impl/write.ipp
@@ -234,7 +234,7 @@ async_write(AsyncWriteStream& stream,
     static_assert(is_AsyncWriteStream<AsyncWriteStream>::value,
         "AsyncWriteStream requirements not met");
     beast::async_completion<WriteHandler,
-        void(error_code)> completion(handler);
+        void(error_code)> completion{handler};
     streambuf sb;
     detail::write_start_line(sb, msg);
     detail::write_fields(sb, msg.fields);
@@ -728,7 +728,7 @@ async_write(AsyncWriteStream& stream,
         message<isRequest, Body, Fields>>::value,
             "Writer requirements not met");
     beast::async_completion<WriteHandler,
-        void(error_code)> completion(handler);
+        void(error_code)> completion{handler};
     detail::write_op<AsyncWriteStream, decltype(completion.handler),
         isRequest, Body, Fields>{completion.handler, stream, msg};
     return completion.result.get();

--- a/include/beast/version.hpp
+++ b/include/beast/version.hpp
@@ -16,6 +16,6 @@
 //
 #define BEAST_VERSION 100000
 
-#define BEAST_VERSION_STRING "1.0.0-b27"
+#define BEAST_VERSION_STRING "1.0.0-b28"
 
 #endif

--- a/include/beast/websocket/detail/stream_base.hpp
+++ b/include/beast/websocket/detail/stream_base.hpp
@@ -66,7 +66,7 @@ protected:
     bool wr_close_;                         // sent close frame
     op* wr_block_;                          // op currenly writing
 
-    ping_data* ping_data_;                  // where to put pong payload
+    ping_data* ping_data_;                  // where to put the payload
     invokable rd_op_;                       // invoked after write completes
     invokable wr_op_;                       // invoked after read completes
     close_reason cr_;                       // set from received close frame

--- a/include/beast/websocket/impl/accept.ipp
+++ b/include/beast/websocket/impl/accept.ipp
@@ -288,7 +288,7 @@ async_accept(ConstBufferSequence const& bs, AcceptHandler&& handler)
             "ConstBufferSequence requirements not met");
     beast::async_completion<
         AcceptHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     accept_op<decltype(completion.handler)>{
         completion.handler, *this, bs};
     return completion.result.get();
@@ -306,7 +306,7 @@ async_accept(http::request<Body, Fields> const& req,
         "AsyncStream requirements requirements not met");
     beast::async_completion<
         AcceptHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     reset();
     response_op<decltype(completion.handler)>{
         completion.handler, *this, req,

--- a/include/beast/websocket/impl/close.ipp
+++ b/include/beast/websocket/impl/close.ipp
@@ -197,7 +197,7 @@ async_close(close_reason const& cr, CloseHandler&& handler)
         "AsyncStream requirements not met");
     beast::async_completion<
         CloseHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     close_op<decltype(completion.handler)>{
         completion.handler, *this, cr};
     return completion.result.get();

--- a/include/beast/websocket/impl/handshake.ipp
+++ b/include/beast/websocket/impl/handshake.ipp
@@ -158,7 +158,7 @@ async_handshake(boost::string_ref const& host,
         "AsyncStream requirements not met");
     beast::async_completion<
         HandshakeHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     handshake_op<decltype(completion.handler)>{
         completion.handler, *this, host, resource};
     return completion.result.get();

--- a/include/beast/websocket/impl/ping.ipp
+++ b/include/beast/websocket/impl/ping.ipp
@@ -195,7 +195,7 @@ async_ping(ping_data const& payload, WriteHandler&& handler)
         "AsyncStream requirements requirements not met");
     beast::async_completion<
         WriteHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     ping_op<decltype(completion.handler)>{
         completion.handler, *this,
             opcode::ping, payload};
@@ -213,7 +213,7 @@ async_pong(ping_data const& payload, WriteHandler&& handler)
         "AsyncStream requirements requirements not met");
     beast::async_completion<
         WriteHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     ping_op<decltype(completion.handler)>{
         completion.handler, *this,
             opcode::pong, payload};

--- a/include/beast/websocket/impl/read.ipp
+++ b/include/beast/websocket/impl/read.ipp
@@ -673,7 +673,7 @@ async_read_frame(frame_info& fi,
     static_assert(beast::is_DynamicBuffer<DynamicBuffer>::value,
         "DynamicBuffer requirements not met");
     beast::async_completion<
-        ReadHandler, void(error_code)> completion(handler);
+        ReadHandler, void(error_code)> completion{handler};
     read_frame_op<DynamicBuffer, decltype(completion.handler)>{
         completion.handler, *this, fi, dynabuf};
     return completion.result.get();
@@ -1079,7 +1079,7 @@ async_read(opcode& op,
         "DynamicBuffer requirements not met");
     beast::async_completion<
         ReadHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     read_op<DynamicBuffer, decltype(completion.handler)>{
         completion.handler, *this, op, dynabuf};
     return completion.result.get();

--- a/include/beast/websocket/impl/write.ipp
+++ b/include/beast/websocket/impl/write.ipp
@@ -516,7 +516,7 @@ async_write_frame(bool fin,
             "ConstBufferSequence requirements not met");
     beast::async_completion<
         WriteHandler, void(error_code)
-            > completion(handler);
+            > completion{handler};
     write_frame_op<ConstBufferSequence, decltype(
         completion.handler)>{completion.handler,
             *this, fin, bs};
@@ -864,7 +864,7 @@ async_write(ConstBufferSequence const& bs, WriteHandler&& handler)
         ConstBufferSequence>::value,
             "ConstBufferSequence requirements not met");
     beast::async_completion<
-        WriteHandler, void(error_code)> completion(handler);
+        WriteHandler, void(error_code)> completion{handler};
     write_op<ConstBufferSequence, decltype(completion.handler)>{
         completion.handler, *this, bs};
     return completion.result.get();

--- a/include/beast/websocket/option.hpp
+++ b/include/beast/websocket/option.hpp
@@ -236,14 +236,15 @@ struct permessage_deflate
 /** Ping callback option.
 
     Sets the callback to be invoked whenever a ping or pong is
-    received during a call to
-    @ref beast::websocket::stream::read,
-    @ref beast::websocket::stream::read_frame,
-    @ref beast::websocket::stream::async_read, or
-    @ref beast::websocket::stream::async_read_frame.
+    received during a call to one of the following functions:
 
-    Unlike completion handlers, the callback will be invoked for
-    each received ping and pong pong during a call to any
+    @li @ref beast::websocket::stream::read
+    @li @ref beast::websocket::stream::read_frame
+    @li @ref beast::websocket::stream::async_read
+    @li @ref beast::websocket::stream::async_read_frame
+
+    Unlike completion handlers, the callback will be invoked
+    for each received ping and pong during a call to any
     synchronous or asynchronous read function. The operation is
     passive, with no associated error code, and triggered by reads.
 

--- a/include/beast/websocket/stream.hpp
+++ b/include/beast/websocket/stream.hpp
@@ -1118,12 +1118,17 @@ public:
         the message type, and the input area of the stream buffer will
         hold all the message payload bytes (which may be zero in length).
 
-        Control frames encountered while reading frame or message data
-        are handled automatically. Pings are replied to with a pong,
-        received pings and pongs invoke the @ref ping_callback if the
-        option is set, and close frames initiate the WebSocket close
-        procedure. When a close frame is received, this call will
-        eventually return @ref error::closed.
+        During reads, the implementation handles control frames as
+        follows:
+
+        @li A pong frame is sent when a ping frame is received.
+
+        @li The @ref ping_callback is invoked when a ping frame
+            or pong frame is received.
+
+        @li The WebSocket close procedure is started if a close frame
+            is received. In this case, the operation will eventually
+            complete with the error set to @ref error::closed.
 
         @param op A value to receive the message type.
         This object must remain valid until the handler is called.
@@ -1153,12 +1158,17 @@ public:
         the message type, and the input area of the stream buffer will
         hold all the message payload bytes (which may be zero in length).
 
-        Control frames encountered while reading frame or message data
-        are handled automatically. Pings are replied to with a pong,
-        received pings and pongs invoke the @ref ping_callback if the
-        option is set, and close frames initiate the WebSocket close
-        procedure. When a close frame is received, this call will
-        eventually return @ref error::closed.
+        During reads, the implementation handles control frames as
+        follows:
+
+        @li The @ref ping_callback is invoked when a ping frame
+            or pong frame is received.
+
+        @li A pong frame is sent when a ping frame is received.
+
+        @li The WebSocket close procedure is started if a close frame
+            is received. In this case, the operation will eventually
+            complete with the error set to @ref error::closed.
 
         @param op A value to receive the message type.
         This object must remain valid until the handler is called.
@@ -1193,12 +1203,17 @@ public:
         the message type, and the input area of the stream buffer will
         hold all the message payload bytes (which may be zero in length).
 
-        Control frames encountered while reading frame or message data
-        are handled automatically. Pings are replied to with a pong,
-        received pings and pongs invoke the @ref ping_callback if the
-        option is set, and close frames initiate the WebSocket close
-        procedure. When a close frame is received, this call will
-        eventually return @ref error::closed.
+        During reads, the implementation handles control frames as
+        follows:
+
+        @li The @ref ping_callback is invoked when a ping frame
+            or pong frame is received.
+
+        @li A pong frame is sent when a ping frame is received.
+
+        @li The WebSocket close procedure is started if a close frame
+            is received. In this case, the operation will eventually
+            complete with the error set to @ref error::closed.
 
         Because of the need to handle control frames, read operations
         can cause writes to take place. These writes are managed
@@ -1248,19 +1263,24 @@ public:
         This call is implemented in terms of one or more calls to the
         stream's `read_some` and `write_some` operations.
 
-        Upon success, fi is filled out to reflect the message payload
-        contents. op is set to binary or text, and the fin flag
+        Upon success, `fi` is filled out to reflect the message payload
+        contents. `op` is set to binary or text, and the `fin` flag
         indicates if all the message data has been read in. To read the
-        entire message, callers should repeat the read_frame operation
-        until fi.fin is true. A message with no payload will have
-        fi.fin == true, and zero bytes placed into the stream buffer.
+        entire message, callers should keep calling @ref read_frame
+        until `fi.fin == true`. A message with no payload will have
+        `fi.fin == true`, and zero bytes placed into the stream buffer.
 
-        Control frames encountered while reading frame or message data
-        are handled automatically. Pings are replied to with a pong,
-        received pings and pongs invoke the @ref ping_callback if the
-        option is set, and close frames initiate the WebSocket close
-        procedure. When a close frame is received, this call will
-        eventually return @ref error::closed.
+        During reads, the implementation handles control frames as
+        follows:
+
+        @li The @ref ping_callback is invoked when a ping frame
+            or pong frame is received.
+
+        @li A pong frame is sent when a ping frame is received.
+
+        @li The WebSocket close procedure is started if a close frame
+            is received. In this case, the operation will eventually
+            complete with the error set to @ref error::closed.
 
         @param fi An object to store metadata about the message.
 
@@ -1286,19 +1306,24 @@ public:
         This call is implemented in terms of one or more calls to the
         stream's `read_some` and `write_some` operations.
 
-        Upon success, fi is filled out to reflect the message payload
-        contents. op is set to binary or text, and the fin flag
+        Upon success, `fi` is filled out to reflect the message payload
+        contents. `op` is set to binary or text, and the `fin` flag
         indicates if all the message data has been read in. To read the
-        entire message, callers should repeat the read_frame operation
-        until fi.fin is true. A message with no payload will have
-        fi.fin == true, and zero bytes placed into the stream buffer.
+        entire message, callers should keep calling @ref read_frame
+        until `fi.fin == true`. A message with no payload will have
+        `fi.fin == true`, and zero bytes placed into the stream buffer.
 
-        Control frames encountered while reading frame or message data
-        are handled automatically. Pings are replied to with a pong,
-        received pings and pongs invoke the @ref ping_callback if the
-        option is set, and close frames initiate the WebSocket close
-        procedure. When a close frame is received, this call will
-        eventually return @ref error::closed.
+        During reads, the implementation handles control frames as
+        follows:
+
+        @li The @ref ping_callback is invoked when a ping frame
+            or pong frame is received.
+
+        @li A pong frame is sent when a ping frame is received.
+
+        @li The WebSocket close procedure is started if a close frame
+            is received. In this case, the operation will eventually
+            complete with the error set to @ref error::closed.
 
         @param fi An object to store metadata about the message.
 
@@ -1328,20 +1353,25 @@ public:
         ensure that the stream performs no other reads until this operation
         completes.
 
-        Upon a successful completion, fi is filled out to reflect the
-        message payload contents. op is set to binary or text, and the
-        fin flag indicates if all the message data has been read in.
-        To read the entire message, callers should repeat the
-        read_frame operation until fi.fin is true. A message with no
-        payload will have fi.fin == true, and zero bytes placed into
-        the stream buffer.
+        Upon a successful completion, `fi` is filled out to reflect the
+        message payload contents. `op` is set to binary or text, and the
+        `fin` flag indicates if all the message data has been read in.
+        To read the entire message, callers should keep calling
+        @ref read_frame until `fi.fin == true`. A message with no payload
+        will have `fi.fin == true`, and zero bytes placed into the stream
+        buffer.
 
-        Control frames encountered while reading frame or message data
-        are handled automatically. Pings are replied to with a pong,
-        received pings and pongs invoke the @ref ping_callback if the
-        option is set, and close frames initiate the WebSocket close
-        procedure. When a close frame is received, this call will
-        eventually return @ref error::closed.
+        During reads, the implementation handles control frames as
+        follows:
+
+        @li The @ref ping_callback is invoked when a ping frame
+            or pong frame is received.
+
+        @li A pong frame is sent when a ping frame is received.
+
+        @li The WebSocket close procedure is started if a close frame
+            is received. In this case, the operation will eventually
+            complete with the error set to @ref error::closed.
 
         Because of the need to handle control frames, read operations
         can cause writes to take place. These writes are managed

--- a/test/core/dynabuf_readstream.cpp
+++ b/test/core/dynabuf_readstream.cpp
@@ -10,7 +10,7 @@
 
 #include <beast/core/streambuf.hpp>
 #include <beast/test/fail_stream.hpp>
-#include <beast/test/string_stream.hpp>
+#include <beast/test/string_istream.hpp>
 #include <beast/test/yield_to.hpp>
 #include <beast/unit_test/suite.hpp>
 #include <boost/asio.hpp>
@@ -54,7 +54,7 @@ public:
         for(n = 0; n < limit; ++n)
         {
             test::fail_stream<
-                test::string_stream> fs(n, ios_, ", world!");
+                test::string_istream> fs(n, ios_, ", world!");
             dynabuf_readstream<
                 decltype(fs)&, streambuf> srs(fs);
             srs.buffer().commit(buffer_copy(
@@ -72,7 +72,7 @@ public:
         for(n = 0; n < limit; ++n)
         {
             test::fail_stream<
-                test::string_stream> fs(n, ios_, ", world!");
+                test::string_istream> fs(n, ios_, ", world!");
             dynabuf_readstream<
                 decltype(fs)&, streambuf> srs(fs);
             srs.capacity(3);
@@ -91,7 +91,7 @@ public:
         for(n = 0; n < limit; ++n)
         {
             test::fail_stream<
-                test::string_stream> fs(n, ios_, ", world!");
+                test::string_istream> fs(n, ios_, ", world!");
             dynabuf_readstream<
                 decltype(fs)&, streambuf> srs(fs);
             srs.buffer().commit(buffer_copy(
@@ -110,7 +110,7 @@ public:
         for(n = 0; n < limit; ++n)
         {
             test::fail_stream<
-                test::string_stream> fs(n, ios_, ", world!");
+                test::string_istream> fs(n, ios_, ", world!");
             dynabuf_readstream<
                 decltype(fs)&, streambuf> srs(fs);
             srs.capacity(3);

--- a/test/http/parser_v1.cpp
+++ b/test/http/parser_v1.cpp
@@ -25,64 +25,8 @@ class parser_v1_test
     , public test::enable_yield_to
 {
 public:
-    void testRegressions()
-    {
-        using boost::asio::buffer;
-
-        // consecutive empty header values
-        {
-            error_code ec;
-            parser_v1<true, string_body, fields> p;
-            std::string const s =
-                "GET / HTTP/1.1\r\n"
-                "X1:\r\n"
-                "X2:\r\n"
-                "X3:x\r\n"
-                "\r\n";
-            p.write(buffer(s), ec);
-            if(! BEAST_EXPECTS(! ec, ec.message()))
-                return;
-            BEAST_EXPECT(p.complete());
-            auto const msg = p.release();
-            BEAST_EXPECT(msg.fields.exists("X1"));
-            BEAST_EXPECT(msg.fields["X1"] == "");
-            BEAST_EXPECT(msg.fields.exists("X2"));
-            BEAST_EXPECT(msg.fields["X2"] == "");
-            BEAST_EXPECT(msg.fields.exists("X3"));
-            BEAST_EXPECT(msg.fields["X3"] == "x");
-        }
-    }
-
-    void testWithBody()
-    {
-        test::string_istream ss{ios_,
-            "GET / HTTP/1.1\r\n"
-            "User-Agent: test\r\n"
-            "Content-Length: 1\r\n"
-            "\r\n"
-            "*"};
-        streambuf rb;
-        header_parser_v1<true, fields> p0;
-        parse(ss, rb, p0);
-        request_header const& reqh = p0.get();
-        BEAST_EXPECT(reqh.method == "GET");
-        BEAST_EXPECT(reqh.url == "/");
-        BEAST_EXPECT(reqh.version == 11);
-        BEAST_EXPECT(reqh.fields["User-Agent"] == "test");
-        BEAST_EXPECT(reqh.fields["Content-Length"] == "1");
-        parser_v1<true, string_body, fields> p =
-            with_body<string_body>(p0);
-        BEAST_EXPECT(p.get().method == "GET");
-        BEAST_EXPECT(p.get().url == "/");
-        BEAST_EXPECT(p.get().version == 11);
-        BEAST_EXPECT(p.get().fields["User-Agent"] == "test");
-        BEAST_EXPECT(p.get().fields["Content-Length"] == "1");
-        parse(ss, rb, p);
-        request<string_body, fields> req = p.release();
-        BEAST_EXPECT(req.body == "*");
-    }
-
-    void run() override
+    void
+    testParse()
     {
         using boost::asio::buffer;
         {
@@ -138,9 +82,75 @@ public:
             BEAST_EXPECT(! ec);
             BEAST_EXPECT(p.complete());
         }
+    }
 
-        testRegressions();
+    void
+    testWithBody()
+    {
+        std::string const raw =
+            "GET / HTTP/1.1\r\n"
+            "User-Agent: test\r\n"
+            "Content-Length: 1\r\n"
+            "\r\n"
+            "*";
+        test::string_istream ss{
+            ios_, raw, raw.size() - 1};
+
+        streambuf rb;
+        header_parser_v1<true, fields> p0;
+        parse(ss, rb, p0);
+        request_header const& reqh = p0.get();
+        BEAST_EXPECT(reqh.method == "GET");
+        BEAST_EXPECT(reqh.url == "/");
+        BEAST_EXPECT(reqh.version == 11);
+        BEAST_EXPECT(reqh.fields["User-Agent"] == "test");
+        BEAST_EXPECT(reqh.fields["Content-Length"] == "1");
+        parser_v1<true, string_body, fields> p =
+            with_body<string_body>(p0);
+        BEAST_EXPECT(p.get().method == "GET");
+        BEAST_EXPECT(p.get().url == "/");
+        BEAST_EXPECT(p.get().version == 11);
+        BEAST_EXPECT(p.get().fields["User-Agent"] == "test");
+        BEAST_EXPECT(p.get().fields["Content-Length"] == "1");
+        parse(ss, rb, p);
+        request<string_body, fields> req = p.release();
+        BEAST_EXPECT(req.body == "*");
+    }
+
+    void
+    testRegressions()
+    {
+        using boost::asio::buffer;
+
+        // consecutive empty header values
+        {
+            error_code ec;
+            parser_v1<true, string_body, fields> p;
+            std::string const s =
+                "GET / HTTP/1.1\r\n"
+                "X1:\r\n"
+                "X2:\r\n"
+                "X3:x\r\n"
+                "\r\n";
+            p.write(buffer(s), ec);
+            if(! BEAST_EXPECTS(! ec, ec.message()))
+                return;
+            BEAST_EXPECT(p.complete());
+            auto const msg = p.release();
+            BEAST_EXPECT(msg.fields.exists("X1"));
+            BEAST_EXPECT(msg.fields["X1"] == "");
+            BEAST_EXPECT(msg.fields.exists("X2"));
+            BEAST_EXPECT(msg.fields["X2"] == "");
+            BEAST_EXPECT(msg.fields.exists("X3"));
+            BEAST_EXPECT(msg.fields["X3"] == "x");
+        }
+    }
+
+    void run() override
+    {
+        testParse();
         testWithBody();
+        testRegressions();
     }
 };
 

--- a/test/http/parser_v1.cpp
+++ b/test/http/parser_v1.cpp
@@ -13,7 +13,7 @@
 #include <beast/http/header_parser_v1.hpp>
 #include <beast/http/parse.hpp>
 #include <beast/http/string_body.hpp>
-#include <beast/test/string_stream.hpp>
+#include <beast/test/string_istream.hpp>
 #include <beast/test/yield_to.hpp>
 #include <beast/unit_test/suite.hpp>
 
@@ -55,7 +55,7 @@ public:
 
     void testWithBody()
     {
-        test::string_stream ss{ios_,
+        test::string_istream ss{ios_,
             "GET / HTTP/1.1\r\n"
             "User-Agent: test\r\n"
             "Content-Length: 1\r\n"

--- a/test/http/read.cpp
+++ b/test/http/read.cpp
@@ -13,7 +13,7 @@
 #include <beast/http/fields.hpp>
 #include <beast/http/streambuf_body.hpp>
 #include <beast/test/fail_stream.hpp>
-#include <beast/test/string_stream.hpp>
+#include <beast/test/string_istream.hpp>
 #include <beast/test/yield_to.hpp>
 #include <beast/unit_test/suite.hpp>
 #include <boost/asio/spawn.hpp>
@@ -95,7 +95,7 @@ public:
                 sb.prepare(len), buffer(s, len)));
             test::fail_counter fc(n);
             test::fail_stream<
-                test::string_stream> fs{fc, ios_, ""};
+                test::string_istream> fs{fc, ios_, ""};
             fail_parser<isRequest> p(fc);
             error_code ec;
             parse(fs, sb, p, ec);
@@ -110,7 +110,7 @@ public:
             sb.commit(buffer_copy(
                 sb.prepare(pre), buffer(s, pre)));
             test::fail_counter fc(n);
-            test::fail_stream<test::string_stream> fs{
+            test::fail_stream<test::string_istream> fs{
                 fc, ios_, std::string{s + pre, len - pre}};
             fail_parser<isRequest> p(fc);
             error_code ec;
@@ -126,7 +126,7 @@ public:
                 sb.prepare(len), buffer(s, len)));
             test::fail_counter fc(n);
             test::fail_stream<
-                test::string_stream> fs{fc, ios_, ""};
+                test::string_istream> fs{fc, ios_, ""};
             fail_parser<isRequest> p(fc);
             error_code ec;
             async_parse(fs, sb, p, do_yield[ec]);
@@ -141,7 +141,7 @@ public:
             sb.commit(buffer_copy(
                 sb.prepare(pre), buffer(s, pre)));
             test::fail_counter fc(n);
-            test::fail_stream<test::string_stream> fs{
+            test::fail_stream<test::string_istream> fs{
                 fc, ios_, std::string{s + pre, len - pre}};
             fail_parser<isRequest> p(fc);
             error_code ec;
@@ -156,7 +156,7 @@ public:
             sb.commit(buffer_copy(
                 sb.prepare(len), buffer(s, len)));
             test::fail_counter fc{n};
-            test::string_stream ss{ios_, s};
+            test::string_istream ss{ios_, s};
             parser_v1<isRequest, fail_body, fields> p{fc};
             error_code ec;
             parse(ss, sb, p, ec);
@@ -171,7 +171,7 @@ public:
         try
         {
             streambuf sb;
-            test::string_stream ss(ios_, "GET / X");
+            test::string_istream ss(ios_, "GET / X");
             parser_v1<true, streambuf_body, fields> p;
             parse(ss, sb, p);
             fail();
@@ -251,7 +251,7 @@ public:
 
         for(n = 0; n < limit; ++n)
         {
-            test::fail_stream<test::string_stream> fs{n, ios_,
+            test::fail_stream<test::string_istream> fs{n, ios_,
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
                 "User-Agent: test\r\n"
@@ -273,7 +273,7 @@ public:
 
         for(n = 0; n < limit; ++n)
         {
-            test::fail_stream<test::string_stream> fs(n, ios_,
+            test::fail_stream<test::string_istream> fs(n, ios_,
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
                 "User-Agent: test\r\n"
@@ -297,7 +297,7 @@ public:
 
         for(n = 0; n < limit; ++n)
         {
-            test::fail_stream<test::string_stream> fs(n, ios_,
+            test::fail_stream<test::string_istream> fs(n, ios_,
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
                 "User-Agent: test\r\n"
@@ -319,7 +319,7 @@ public:
 
         for(n = 0; n < limit; ++n)
         {
-            test::fail_stream<test::string_stream> fs(n, ios_,
+            test::fail_stream<test::string_istream> fs(n, ios_,
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
                 "User-Agent: test\r\n"
@@ -337,7 +337,7 @@ public:
 
         for(n = 0; n < limit; ++n)
         {
-            test::fail_stream<test::string_stream> fs(n, ios_,
+            test::fail_stream<test::string_istream> fs(n, ios_,
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
                 "User-Agent: test\r\n"
@@ -358,7 +358,7 @@ public:
     {
         {
             streambuf sb;
-            test::string_stream ss(ios_, "");
+            test::string_istream ss(ios_, "");
             parser_v1<true, streambuf_body, fields> p;
             error_code ec;
             parse(ss, sb, p, ec);
@@ -366,7 +366,7 @@ public:
         }
         {
             streambuf sb;
-            test::string_stream ss(ios_, "");
+            test::string_istream ss(ios_, "");
             parser_v1<true, streambuf_body, fields> p;
             error_code ec;
             async_parse(ss, sb, p, do_yield[ec]);

--- a/test/http/streambuf_body.cpp
+++ b/test/http/streambuf_body.cpp
@@ -13,7 +13,7 @@
 #include <beast/http/parser_v1.hpp>
 #include <beast/http/read.hpp>
 #include <beast/http/write.hpp>
-#include <beast/test/string_stream.hpp>
+#include <beast/test/string_istream.hpp>
 #include <beast/unit_test/suite.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -33,7 +33,7 @@ public:
             "Content-Length: 3\r\n"
             "\r\n"
             "xyz";
-        test::string_stream ss(ios_, s);
+        test::string_istream ss(ios_, s);
         parser_v1<false, streambuf_body, fields> p;
         streambuf sb;
         parse(ss, sb, p);

--- a/test/http/write.cpp
+++ b/test/http/write.cpp
@@ -17,6 +17,7 @@
 #include <beast/core/streambuf.hpp>
 #include <beast/core/to_string.hpp>
 #include <beast/test/fail_stream.hpp>
+#include <beast/test/string_ostream.hpp>
 #include <beast/test/yield_to.hpp>
 #include <beast/unit_test/suite.hpp>
 #include <boost/asio/error.hpp>
@@ -31,68 +32,6 @@ class write_test
     , public test::enable_yield_to
 {
 public:
-    class string_write_stream
-    {
-        boost::asio::io_service& ios_;
-
-    public:
-        std::string str;
-
-        explicit
-        string_write_stream(boost::asio::io_service& ios)
-            : ios_(ios)
-        {
-        }
-
-        boost::asio::io_service&
-        get_io_service()
-        {
-            return ios_;
-        }
-
-        template<class ConstBufferSequence>
-        std::size_t
-        write_some(ConstBufferSequence const& buffers)
-        {
-            error_code ec;
-            auto const n = write_some(buffers, ec);
-            if(ec)
-                throw system_error{ec};
-            return n;
-        }
-
-        template<class ConstBufferSequence>
-        std::size_t
-        write_some(
-            ConstBufferSequence const& buffers, error_code&)
-        {
-            auto const n = buffer_size(buffers);
-            using boost::asio::buffer_size;
-            using boost::asio::buffer_cast;
-            str.reserve(str.size() + n);
-            for(auto const& buffer : buffers)
-                str.append(buffer_cast<char const*>(buffer),
-                    buffer_size(buffer));
-            return n;
-        }
-
-        template<class ConstBufferSequence, class WriteHandler>
-        typename async_completion<
-            WriteHandler, void(error_code)>::result_type
-        async_write_some(ConstBufferSequence const& buffers,
-            WriteHandler&& handler)
-        {
-            error_code ec;
-            auto const bytes_transferred = write_some(buffers, ec);
-            async_completion<
-                WriteHandler, void(error_code, std::size_t)
-                    > completion(handler);
-            get_io_service().post(
-                bind_handler(completion.handler, ec, bytes_transferred));
-            return completion.result.get();
-        }
-    };
-
     struct unsized_body
     {
         using value_type = std::string;
@@ -225,7 +164,7 @@ public:
     std::string
     str(message<isRequest, Body, Fields> const& m)
     {
-        string_write_stream ss(ios_);
+        test::string_ostream ss(ios_);
         write(ss, m);
         return ss.str;
     }
@@ -240,7 +179,7 @@ public:
             m.url = "/";
             m.fields.insert("User-Agent", "test");
             error_code ec;
-            string_write_stream ss{ios_};
+            test::string_ostream ss{ios_};
             async_write(ss, m, do_yield[ec]);
             if(BEAST_EXPECTS(! ec, ec.message()))
                 BEAST_EXPECT(ss.str ==
@@ -256,7 +195,7 @@ public:
             m.fields.insert("Server", "test");
             m.fields.insert("Content-Length", "5");
             error_code ec;
-            string_write_stream ss{ios_};
+            test::string_ostream ss{ios_};
             async_write(ss, m, do_yield[ec]);
             if(BEAST_EXPECTS(! ec, ec.message()))
                 BEAST_EXPECT(ss.str ==
@@ -279,7 +218,7 @@ public:
             m.fields.insert("Content-Length", "5");
             m.body = "*****";
             error_code ec;
-            string_write_stream ss{ios_};
+            test::string_ostream ss{ios_};
             async_write(ss, m, do_yield[ec]);
             if(BEAST_EXPECTS(! ec, ec.message()))
                 BEAST_EXPECT(ss.str ==
@@ -298,7 +237,7 @@ public:
             m.fields.insert("Transfer-Encoding", "chunked");
             m.body = "*****";
             error_code ec;
-            string_write_stream ss(ios_);
+            test::string_ostream ss(ios_);
             async_write(ss, m, do_yield[ec]);
             if(BEAST_EXPECTS(! ec, ec.message()))
                 BEAST_EXPECT(ss.str ==
@@ -322,7 +261,7 @@ public:
         {
             test::fail_counter fc(n);
             test::fail_stream<
-                string_write_stream> fs(fc, ios_);
+                test::string_ostream> fs(fc, ios_);
             message<true, fail_body, fields> m(
                 std::piecewise_construct,
                     std::forward_as_tuple(fc, ios_));
@@ -355,7 +294,7 @@ public:
         {
             test::fail_counter fc(n);
             test::fail_stream<
-                string_write_stream> fs(fc, ios_);
+                test::string_ostream> fs(fc, ios_);
             message<true, fail_body, fields> m(
                 std::piecewise_construct,
                     std::forward_as_tuple(fc, ios_));
@@ -390,7 +329,7 @@ public:
         {
             test::fail_counter fc(n);
             test::fail_stream<
-                string_write_stream> fs(fc, ios_);
+                test::string_ostream> fs(fc, ios_);
             message<true, fail_body, fields> m(
                 std::piecewise_construct,
                     std::forward_as_tuple(fc, ios_));
@@ -425,7 +364,7 @@ public:
         {
             test::fail_counter fc(n);
             test::fail_stream<
-                string_write_stream> fs(fc, ios_);
+                test::string_ostream> fs(fc, ios_);
             message<true, fail_body, fields> m(
                 std::piecewise_construct,
                     std::forward_as_tuple(fc, ios_));
@@ -455,7 +394,7 @@ public:
         {
             test::fail_counter fc(n);
             test::fail_stream<
-                string_write_stream> fs(fc, ios_);
+                test::string_ostream> fs(fc, ios_);
             message<true, fail_body, fields> m(
                 std::piecewise_construct,
                     std::forward_as_tuple(fc, ios_));
@@ -547,7 +486,7 @@ public:
             m.fields.insert("User-Agent", "test");
             m.body = "*";
             prepare(m);
-            string_write_stream ss(ios_);
+            test::string_ostream ss(ios_);
             error_code ec;
             write(ss, m, ec);
             BEAST_EXPECT(ec == boost::asio::error::eof);
@@ -584,7 +523,7 @@ public:
             m.fields.insert("User-Agent", "test");
             m.body = "*";
             prepare(m, connection::close);
-            string_write_stream ss(ios_);
+            test::string_ostream ss(ios_);
             error_code ec;
             write(ss, m, ec);
             BEAST_EXPECT(ec == boost::asio::error::eof);
@@ -621,7 +560,7 @@ public:
             m.fields.insert("User-Agent", "test");
             m.body = "*";
             prepare(m);
-            string_write_stream ss(ios_);
+            test::string_ostream ss(ios_);
             error_code ec;
             write(ss, m, ec);
             BEAST_EXPECT(ss.str ==

--- a/test/websocket/stream.cpp
+++ b/test/websocket/stream.cpp
@@ -14,7 +14,7 @@
 #include <beast/core/streambuf.hpp>
 #include <beast/core/to_string.hpp>
 #include <beast/test/fail_stream.hpp>
-#include <beast/test/string_stream.hpp>
+#include <beast/test/string_istream.hpp>
 #include <beast/test/yield_to.hpp>
 #include <beast/unit_test/suite.hpp>
 #include <boost/asio.hpp>
@@ -172,7 +172,7 @@ public:
                 req.fields.insert("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
                 req.fields.insert("Sec-WebSocket-Version", "13");
                 stream<test::fail_stream<
-                    test::string_stream>> ws(n, ios_, "");
+                    test::string_istream>> ws(n, ios_, "");
                 try
                 {
                     ws.accept(req);
@@ -186,7 +186,7 @@ public:
         }
         {
             // valid
-            stream<test::string_stream> ws(ios_,
+            stream<test::string_istream> ws(ios_,
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost:80\r\n"
                 "Upgrade: WebSocket\r\n"
@@ -207,7 +207,7 @@ public:
         }
         {
             // invalid
-            stream<test::string_stream> ws(ios_,
+            stream<test::string_istream> ws(ios_,
                 "GET / HTTP/1.0\r\n"
                 "\r\n"
             );
@@ -230,7 +230,7 @@ public:
             {
                 for(std::size_t i = 0; i < s.size(); ++i)
                 {
-                    stream<test::string_stream> ws(ios_,
+                    stream<test::string_istream> ws(ios_,
                         s.substr(i, s.size() - i));
                     ws.set_option(keep_alive{true});
                     try
@@ -339,7 +339,7 @@ public:
         auto const check =
             [&](std::string const& s)
             {
-                stream<test::string_stream> ws(ios_, s);
+                stream<test::string_istream> ws(ios_, s);
                 try
                 {
                     ws.handshake("localhost:80", "/");


### PR DESCRIPTION
* Split out and rename test stream classes
* Restyle async result constructions
* Fix HTTP split parse edge case
