### PR TITLE
Fix compile error when use with asio ssl stream.

### DIFF
--- a/include/beast/core/dynabuf_readstream.hpp
+++ b/include/beast/core/dynabuf_readstream.hpp
@@ -98,7 +98,7 @@ class dynabuf_readstream
 
     DynamicBuffer sb_;
     std::size_t capacity_ = 0;
-    Stream next_layer_;
+    Stream & next_layer_;
 
 public:
     /// The type of the internal buffer


### PR DESCRIPTION
Without this fix, I got compile error when using Beast with Boost.asio ssl stream, because `asio::ssl::stream` is not copyable:

`In file included from /home/alexey/projects/dinect/Beast/include/beast/core/dynabuf_readstream.hpp:361:0,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/stream.hpp:16,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket.hpp:16,
                 from src/subscription.hpp:8,
                 from src/subscription.cpp:5:
/home/alexey/projects/dinect/Beast/include/beast/core/impl/dynabuf_readstream.ipp: In instantiation of ‘beast::dynabuf_readstream<Stream, DynamicBuffer>::dynabuf_readstream(Args&& ...) [with Args = {boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::stream_socket_service<boost::asio::ip::tcp> > >&}; Stream = boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >; DynamicBuffer = beast::basic_streambuf<std::allocator<char> >]’:
/home/alexey/projects/dinect/Beast/include/beast/websocket/impl/stream.ipp:39:42:   required from ‘beast::websocket::stream<NextLayer>::stream(Args&& ...) [with Args = {boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::stream_socket_service<boost::asio::ip::tcp> > >&}; NextLayer = boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >]’
src/subscription.cpp:38:55:   required from here
/home/alexey/projects/dinect/Beast/include/beast/core/impl/dynabuf_readstream.ipp:155:46: error: use of deleted function ‘boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >::stream(const boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >&)’
     : next_layer_(std::forward<Args>(args)...)
                                              ^
In file included from src/subscription.hpp:10:0,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:74:7: note: ‘boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >::stream(const boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >&)’ is implicitly deleted because the default definition would be ill-formed:
 class stream :
       ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio/detail/call_stack.hpp:19:0,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/impl/handler_alloc_hook.ipp:19,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/handler_alloc_hook.hpp:80,
                 from /home/alexey/projects/dinect/Beast/include/beast/core/handler_helpers.hpp:12,
                 from /home/alexey/projects/dinect/Beast/include/beast/core/impl/handler_ptr.ipp:11,
                 from /home/alexey/projects/dinect/Beast/include/beast/core/handler_ptr.hpp:202,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/detail/invokable.hpp:11,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/detail/stream_base.hpp:16,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/stream.hpp:13,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket.hpp:16,
                 from src/subscription.hpp:8,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/detail/noncopyable.hpp:32:3: error: ‘boost::asio::detail::noncopyable::noncopyable(const boost::asio::detail::noncopyable&)’ is private
   noncopyable(const noncopyable&);
   ^
In file included from src/subscription.hpp:10:0,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:74:7: error: within this context
 class stream :
       ^
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:74:7: error: use of deleted function ‘boost::asio::basic_stream_socket<boost::asio::ip::tcp>::basic_stream_socket(const boost::asio::basic_stream_socket<boost::asio::ip::tcp>&)’
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio.hpp:31:0,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/stream.hpp:19,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket.hpp:16,
                 from src/subscription.hpp:8,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/basic_stream_socket.hpp:46:7: note: ‘boost::asio::basic_stream_socket<boost::asio::ip::tcp>::basic_stream_socket(const boost::asio::basic_stream_socket<boost::asio::ip::tcp>&)’ is implicitly declared as deleted because ‘boost::asio::basic_stream_socket<boost::asio::ip::tcp>’ declares a move constructor or move assignment operator
 class basic_stream_socket
       ^
In file included from src/subscription.hpp:10:0,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:74:7: error: use of deleted function ‘boost::asio::ssl::detail::stream_core::stream_core(const boost::asio::ssl::detail::stream_core&)’
 class stream :
       ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/io.hpp:22:0,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:31,
                 from src/subscription.hpp:10,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/stream_core.hpp:39:8: note: ‘boost::asio::ssl::detail::stream_core::stream_core(const boost::asio::ssl::detail::stream_core&)’ is implicitly deleted because the default definition would be ill-formed:
 struct stream_core
        ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/buffered_handshake_op.hpp:21:0,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:29,
                 from src/subscription.hpp:10,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/engine.hpp:116:3: error: ‘boost::asio::ssl::detail::engine::engine(const boost::asio::ssl::detail::engine&)’ is private
   engine(const engine&);
   ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/io.hpp:22:0,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:31,
                 from src/subscription.hpp:10,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/stream_core.hpp:39:8: error: within this context
 struct stream_core
        ^
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/stream_core.hpp:39:8: error: use of deleted function ‘boost::asio::basic_deadline_timer<boost::posix_time::ptime>::basic_deadline_timer(const boost::asio::basic_deadline_timer<boost::posix_time::ptime>&)’
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio.hpp:22:0,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/stream.hpp:19,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket.hpp:16,
                 from src/subscription.hpp:8,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/basic_deadline_timer.hpp:126:7: note: ‘boost::asio::basic_deadline_timer<boost::posix_time::ptime>::basic_deadline_timer(const boost::asio::basic_deadline_timer<boost::posix_time::ptime>&)’ is implicitly deleted because the default definition would be ill-formed:
 class basic_deadline_timer
       ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio/basic_socket.hpp:20:0,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/basic_datagram_socket.hpp:20,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio.hpp:21,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/stream.hpp:19,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket.hpp:16,
                 from src/subscription.hpp:8,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/basic_io_object.hpp:169:3: error: ‘boost::asio::basic_io_object<IoObjectService, Movable>::basic_io_object(const boost::asio::basic_io_object<IoObjectService, Movable>&) [with IoObjectService = boost::asio::deadline_timer_service<boost::posix_time::ptime, boost::asio::time_traits<boost::posix_time::ptime> >; bool Movable = false]’ is private
   basic_io_object(const basic_io_object&);
   ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio.hpp:22:0,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket/stream.hpp:19,
                 from /home/alexey/projects/dinect/Beast/include/beast/websocket.hpp:16,
                 from src/subscription.hpp:8,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/basic_deadline_timer.hpp:126:7: error: within this context
 class basic_deadline_timer
       ^
In file included from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/io.hpp:22:0,
                 from /home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/stream.hpp:31,
                 from src/subscription.hpp:10,
                 from src/subscription.cpp:5:
/home/alexey/projects/ms/boost_1_64_0/boost/asio/ssl/detail/stream_core.hpp:39:8: error: use of deleted function ‘boost::asio::basic_deadline_timer<boost::posix_time::ptime>::basic_deadline_timer(const boost::asio::basic_deadline_timer<boost::posix_time::ptime>&)’
 struct stream_core
        ^`