### PR TITLE
Fix file_body::get() not setting the more flag correctly

### DIFF
--- a/examples/file_body.hpp
+++ b/examples/file_body.hpp
@@ -95,7 +95,7 @@ struct file_body
             BOOST_ASSERT(nread != 0);
             offset_ += nread;
             return {{const_buffers_type{buf_, nread},
-                offset_ >= size_}};
+                offset_ < size_}};
         }
     };
 };


### PR DESCRIPTION
The check for more data actually checked if the end of data was reached
so it was logically inverted.

This fixes #434