### PR TITLE
V65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 65:
+
+* Enable narrowing warning on msvc cmake
+
+--------------------------------------------------------------------------------
+
 Version 64:
 
 * Simplify buffered_read_stream composed op

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 65:
 * Fix integer types in deflate_stream::bi_reverse
 * Fix narrowing in static_ostream
 * Fix narrowing in ostream
+* Fix narrowing in inflate_stream
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 65:
 * Fix narrowing in inflate_stream
 * Fix narrowing in deflate_stream
 * Fix integer warnings
+* Enable unused variable warning on msvc cmake
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 65:
 
 * Enable narrowing warning on msvc cmake
 * Fix integer types in deflate_stream::bi_reverse
+* Fix narrowing in static_ostream
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 65:
 
 * Enable narrowing warning on msvc cmake
+* Fix integer types in deflate_stream::bi_reverse
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 65:
 * Fix narrowing in static_ostream
 * Fix narrowing in ostream
 * Fix narrowing in inflate_stream
+* Fix narrowing in deflate_stream
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 65:
 * Enable narrowing warning on msvc cmake
 * Fix integer types in deflate_stream::bi_reverse
 * Fix narrowing in static_ostream
+* Fix narrowing in ostream
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 65:
 * Fix narrowing in ostream
 * Fix narrowing in inflate_stream
 * Fix narrowing in deflate_stream
+* Fix integer warnings
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 64)
+project (Beast VERSION 65)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (MSVC)
     add_definitions (-D_SCL_SECURE_NO_WARNINGS=1)
     add_definitions (-D_CRT_SECURE_NO_WARNINGS=1)
 
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100 /wd4244 /MP /W4 /bigobj")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100 /MP /W4 /bigobj")
     set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Ob2 /Oi /Ot /GL")
     set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /Oi /Ot")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (MSVC)
     add_definitions (-D_SCL_SECURE_NO_WARNINGS=1)
     add_definitions (-D_CRT_SECURE_NO_WARNINGS=1)
 
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100 /MP /W4 /bigobj")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W4 /bigobj")
     set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Ob2 /Oi /Ot /GL")
     set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /Oi /Ot")
 

--- a/Jamroot
+++ b/Jamroot
@@ -91,7 +91,7 @@ project beast
     <toolset>clang:<cxxflags>-Wrange-loop-analysis
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS=1
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS=1
-    <toolset>msvc:<cxxflags>"/wd4100 /wd4251 /bigobj"
+    <toolset>msvc:<cxxflags>"/bigobj"
     <toolset>msvc:<variant>release:<cxxflags>"/Ob2 /Oi /Ot"
     <os>LINUX:<define>_XOPEN_SOURCE=600
     <os>LINUX:<define>_GNU_SOURCE=1

--- a/example/doc/http_examples.hpp
+++ b/example/doc/http_examples.hpp
@@ -706,12 +706,13 @@ read_istream(
         if(is.rdbuf()->in_avail() > 0)
         {
             // Get a mutable buffer sequence for writing
-            auto const mb = buffer.prepare(is.rdbuf()->in_avail());
+            auto const mb = buffer.prepare(
+                static_cast<std::size_t>(is.rdbuf()->in_avail()));
 
             // Now get everything we can from the istream
-            buffer.commit(is.readsome(
+            buffer.commit(static_cast<std::size_t>(is.readsome(
                 boost::asio::buffer_cast<char*>(mb),
-                boost::asio::buffer_size(mb)));
+                boost::asio::buffer_size(mb))));
         }
         else if(buffer.size() == 0)
         {
@@ -736,7 +737,7 @@ read_istream(
                 }
 
                 // Commit the characters we got to the buffer.
-                buffer.commit(is.gcount());
+                buffer.commit(static_cast<std::size_t>(is.gcount()));
             }
             else
             {

--- a/example/doc/http_examples.hpp
+++ b/example/doc/http_examples.hpp
@@ -950,6 +950,7 @@ void custom_parser<isRequest>::
 on_request(verb method, string_view method_str,
     string_view path, int version, error_code& ec)
 {
+    boost::ignore_unused(method, method_str, path, version);
     ec = {};
 }
 
@@ -958,6 +959,7 @@ void custom_parser<isRequest>::
 on_response(int status, string_view reason,
     int version, error_code& ec)
 {
+    boost::ignore_unused(status, reason, version);
     ec = {};
 }
 
@@ -966,6 +968,7 @@ void custom_parser<isRequest>::
 on_field(field f, string_view name,
     string_view value, error_code& ec)
 {
+    boost::ignore_unused(f, name, value);
     ec = {};
 }
 
@@ -981,6 +984,7 @@ void custom_parser<isRequest>::
 on_body(boost::optional<std::uint64_t> const& content_length,
     error_code& ec)
 {
+    boost::ignore_unused(content_length);
     ec = {};
 }
 
@@ -988,6 +992,7 @@ template<bool isRequest>
 void custom_parser<isRequest>::
 on_data(string_view s, error_code& ec)
 {
+    boost::ignore_unused(s);
     ec = {};
 }
 
@@ -996,6 +1001,7 @@ void custom_parser<isRequest>::
 on_chunk(std::uint64_t size,
     string_view extension, error_code& ec)
 {
+    boost::ignore_unused(size, extension);
     ec = {};
 }
 

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -8,6 +8,7 @@
 #include <beast/core.hpp>
 #include <boost/asio.hpp>
 #include <cstddef>
+#include <iostream>
 #include <memory>
 #include <utility>
 
@@ -328,7 +329,7 @@ async_echo(AsyncStream& stream, CompletionToken&& token)
 
 //]
 
-int main()
+int main(int, char** argv)
 {
     using address_type = boost::asio::ip::address;
     using socket_type = boost::asio::ip::tcp::socket;
@@ -347,6 +348,8 @@ int main()
     async_echo(sock,
         [&](beast::error_code ec)
         {
+            if(ec)
+                std::cerr << argv[0] << ": " << ec.message() << std::endl;
         });
     ios.run();
     return 0;

--- a/example/server-framework/file_body.hpp
+++ b/example/server-framework/file_body.hpp
@@ -346,6 +346,8 @@ void
 file_body::writer::
 init(boost::optional<std::uint64_t> const& content_length, beast::error_code& ec)
 {
+    boost::ignore_unused(content_length);
+
     // Attempt to open the file for writing
     file_ = fopen(path_.string().c_str(), "wb");
 

--- a/example/server-framework/file_service.hpp
+++ b/example/server-framework/file_service.hpp
@@ -111,6 +111,8 @@ public:
         beast::http::request<Body, Fields>&& req,
         Send const& send) const
     {
+        boost::ignore_unused(ep);
+
         // Determine our action based on the method
         switch(req.method())
         {
@@ -219,6 +221,7 @@ private:
         beast::http::request<Body, Fields> const& req,
         boost::filesystem::path const& rel_path) const
     {
+        boost::ignore_unused(rel_path);
         beast::http::response<beast::http::string_body> res;
         res.version = req.version;
         res.result(beast::http::status::not_found);

--- a/example/server-framework/ssl_certificate.hpp
+++ b/example/server-framework/ssl_certificate.hpp
@@ -119,7 +119,7 @@ ssl_certificate::construct()
         "-----END DH PARAMETERS-----\n";
     
     ctx_.set_password_callback(
-        [](std::size_t size,
+        [](std::size_t,
             boost::asio::ssl::context_base::password_purpose)
         {
             return "test";

--- a/example/server-framework/write_msg.hpp
+++ b/example/server-framework/write_msg.hpp
@@ -57,6 +57,7 @@ class write_msg_op
             : stream(stream_)
             , msg(std::move(msg_))
         {
+            boost::ignore_unused(handler);
         }
     };
 

--- a/extras/beast/test/string_iostream.hpp
+++ b/extras/beast/test/string_iostream.hpp
@@ -148,7 +148,7 @@ public:
     friend
     void
     teardown(websocket::teardown_tag,
-        string_iostream& stream,
+        string_iostream&,
             boost::system::error_code& ec)
     {
         ec.assign(0, ec.category());

--- a/extras/beast/test/string_istream.hpp
+++ b/extras/beast/test/string_istream.hpp
@@ -136,7 +136,7 @@ public:
     friend
     void
     teardown(websocket::teardown_tag,
-        string_istream& stream,
+        string_istream&,
             boost::system::error_code& ec)
     {
         ec.assign(0, ec.category());

--- a/extras/beast/test/string_ostream.hpp
+++ b/extras/beast/test/string_ostream.hpp
@@ -57,7 +57,7 @@ public:
 
     template<class MutableBufferSequence>
     std::size_t
-    read_some(MutableBufferSequence const& buffers,
+    read_some(MutableBufferSequence const&,
         error_code& ec)
     {
         ec = boost::asio::error::eof;
@@ -67,7 +67,7 @@ public:
     template<class MutableBufferSequence, class ReadHandler>
     async_return_type<
         ReadHandler, void(error_code, std::size_t)>
-    async_read_some(MutableBufferSequence const& buffers,
+    async_read_some(MutableBufferSequence const&,
         ReadHandler&& handler)
     {
         async_completion<ReadHandler,
@@ -124,7 +124,7 @@ public:
     friend
     void
     teardown(websocket::teardown_tag,
-        string_ostream& stream,
+        string_ostream&,
             boost::system::error_code& ec)
     {
         ec.assign(0, ec.category());

--- a/include/beast/config.hpp
+++ b/include/beast/config.hpp
@@ -8,6 +8,7 @@
 #ifndef BEAST_CONFIG_HPP
 #define BEAST_CONFIG_HPP
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/static_assert.hpp>
 
 /*

--- a/include/beast/core/detail/ostream.hpp
+++ b/include/beast/core/detail/ostream.hpp
@@ -105,7 +105,8 @@ public:
     {
         if(! Traits::eq_int_type(ch, Traits::eof()))
         {
-            Traits::assign(*this->pptr(), ch);
+            Traits::assign(*this->pptr(),
+                static_cast<CharT>(ch));
             flush(1);
             prepare();
             return ch;
@@ -185,7 +186,8 @@ public:
     {
         if(! Traits::eq_int_type(ch, Traits::eof()))
         {
-            Traits::assign(*this->pptr(), ch);
+            Traits::assign(*this->pptr(),
+                static_cast<CharT>(ch));
             flush(1);
             prepare();
             return ch;

--- a/include/beast/core/detail/static_ostream.hpp
+++ b/include/beast/core/detail/static_ostream.hpp
@@ -57,7 +57,8 @@ public:
     {
         if(! Traits::eq_int_type(ch, Traits::eof()))
         {
-            Traits::assign(*this->pptr(), ch);
+            Traits::assign(*this->pptr(),
+                static_cast<CharT>(ch));
             flush(1);
             prepare();
             return ch;

--- a/include/beast/core/detail/type_traits.hpp
+++ b/include/beast/core/detail/type_traits.hpp
@@ -62,19 +62,6 @@ inline
 void
 accept_rv(T){}
 
-template<class... Ts>
-inline
-void
-ignore_unused(Ts const& ...)
-{
-}
-
-template<class... Ts>
-inline
-void
-ignore_unused()
-{}
-
 template<class U>
 std::size_t constexpr
 max_sizeof()

--- a/include/beast/core/handler_alloc.hpp
+++ b/include/beast/core/handler_alloc.hpp
@@ -134,8 +134,9 @@ public:
     template<class U>
     friend
     bool
-    operator==(handler_alloc const& lhs,
-        handler_alloc<U, Handler> const& rhs)
+    operator==(
+        handler_alloc const&,
+        handler_alloc<U, Handler> const&)
     {
         return true;
     }
@@ -143,7 +144,8 @@ public:
     template<class U>
     friend
     bool
-    operator!=(handler_alloc const& lhs,
+    operator!=(
+        handler_alloc const& lhs,
         handler_alloc<U, Handler> const& rhs)
     {
         return ! (lhs == rhs);

--- a/include/beast/core/impl/static_string.ipp
+++ b/include/beast/core/impl/static_string.ipp
@@ -524,7 +524,7 @@ assign_char(CharT ch, std::true_type) ->
 template<std::size_t N, class CharT, class Traits>
 auto
 static_string<N, CharT, Traits>::
-assign_char(CharT ch, std::false_type) ->
+assign_char(CharT, std::false_type) ->
     static_string&
 {
     BOOST_THROW_EXCEPTION(std::length_error{

--- a/include/beast/http/empty_body.hpp
+++ b/include/beast/http/empty_body.hpp
@@ -90,7 +90,7 @@ struct empty_body
     {
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest, empty_body, Fields>& msg)
+        writer(message<isRequest, empty_body, Fields>&)
         {
         }
 

--- a/include/beast/http/impl/fields.ipp
+++ b/include/beast/http/impl/fields.ipp
@@ -230,7 +230,7 @@ template<class Allocator>
 template<class String>
 void
 basic_fields<Allocator>::reader::
-prepare(String& s, basic_fields const& f,
+prepare(String& s, basic_fields const&,
     unsigned version, verb v)
 {
     if(v == verb::unknown)
@@ -271,7 +271,7 @@ template<class Allocator>
 template<class String>
 void
 basic_fields<Allocator>::reader::
-prepare(String& s,basic_fields const& f,
+prepare(String& s, basic_fields const&,
     unsigned version, unsigned code)
 {
     if(version == 11)

--- a/include/beast/http/impl/read.ipp
+++ b/include/beast/http/impl/read.ipp
@@ -318,7 +318,7 @@ class read_msg_op
         message_type& m;
         parser_type p;
 
-        data(Handler& handler, Stream& s_,
+        data(Handler&, Stream& s_,
                 DynamicBuffer& b_, message_type& m_)
             : s(s_)
             , b(b_)

--- a/include/beast/http/impl/write.ipp
+++ b/include/beast/http/impl/write.ipp
@@ -358,7 +358,7 @@ class write_msg_op
         serializer<isRequest,
             Body, Fields, no_chunk_decorator> sr;
 
-        data(Handler& h, Stream& s_, message<
+        data(Handler&, Stream& s_, message<
                 isRequest, Body, Fields>& m_)
             : s(s_)
             , sr(m_, no_chunk_decorator{})

--- a/include/beast/version.hpp
+++ b/include/beast/version.hpp
@@ -18,7 +18,7 @@
     This is a simple integer that is incremented by one every time
     a set of code changes is merged to the master or develop branch.
 */
-#define BEAST_VERSION 64
+#define BEAST_VERSION 65
 
 #define BEAST_VERSION_STRING "Beast/" BOOST_STRINGIZE(BEAST_VERSION)
 

--- a/include/beast/websocket/impl/accept.ipp
+++ b/include/beast/websocket/impl/accept.ipp
@@ -175,7 +175,7 @@ class stream<NextLayer>::accept_op
         Decorator decorator;
         http::request_parser<http::empty_body> p;
 
-        data(Handler& handler, stream<NextLayer>& ws_,
+        data(Handler&, stream<NextLayer>& ws_,
                 Decorator const& decorator_)
             : ws(ws_)
             , decorator(decorator_)
@@ -183,7 +183,7 @@ class stream<NextLayer>::accept_op
         }
 
         template<class Buffers>
-        data(Handler& handler, stream<NextLayer>& ws_,
+        data(Handler&, stream<NextLayer>& ws_,
             Buffers const& buffers,
                 Decorator const& decorator_)
             : ws(ws_)

--- a/include/beast/websocket/impl/write.ipp
+++ b/include/beast/websocket/impl/write.ipp
@@ -559,7 +559,7 @@ class stream<NextLayer>::write_op
         consuming_buffers<Buffers> cb;
         std::size_t remain;
 
-        data(Handler& handler, stream<NextLayer>& ws_,
+        data(Handler&, stream<NextLayer>& ws_,
                 Buffers const& bs)
             : ws(ws_)
             , cb(bs)

--- a/include/beast/websocket/stream.hpp
+++ b/include/beast/websocket/stream.hpp
@@ -3099,13 +3099,13 @@ private:
 
     static
     void
-    default_decorate_req(request_type& res)
+    default_decorate_req(request_type&)
     {
     }
 
     static
     void
-    default_decorate_res(response_type& res)
+    default_decorate_res(response_type&)
     {
     }
 

--- a/include/beast/zlib/detail/deflate_stream.hpp
+++ b/include/beast/zlib/detail/deflate_stream.hpp
@@ -646,9 +646,10 @@ protected:
             init();
     }
 
+    template<class Unsigned>
     static
-    unsigned
-    bi_reverse(unsigned code, int len);
+    Unsigned
+    bi_reverse(Unsigned code, unsigned len);
 
     template<class = void>
     static
@@ -742,12 +743,15 @@ protected:
 //--------------------------------------------------------------------------
 
 // Reverse the first len bits of a code
+template<class Unsigned>
 inline
-unsigned
+Unsigned
 deflate_stream::
-bi_reverse(unsigned code, int len)
+bi_reverse(Unsigned code, unsigned len)
 {
-    unsigned res = 0;
+    BOOST_STATIC_ASSERT(std::is_unsigned<Unsigned>::value);
+    BOOST_ASSERT(len <= 8 * sizeof(unsigned));
+    Unsigned res = 0;
     do
     {
         res |= code & 1;

--- a/include/beast/zlib/detail/deflate_stream.hpp
+++ b/include/beast/zlib/detail/deflate_stream.hpp
@@ -812,7 +812,7 @@ deflate_stream::get_lut() ->
             //std::uint16_t bl_count[maxBits+1];
 
             // Initialize the mapping length (0..255) -> length code (0..28)
-            int length = 0;
+            std::uint8_t length = 0;
             for(std::uint8_t code = 0; code < lengthCodes-1; ++code)
             {
                 tables.base_length[code] = length;
@@ -820,7 +820,7 @@ deflate_stream::get_lut() ->
                 for(unsigned n = 0; n < run; ++n)
                     tables.length_code[length++] = code;
             }
-            BOOST_ASSERT(length == 256);
+            BOOST_ASSERT(length == 0);
             // Note that the length 255 (match length 258) can be represented
             // in two different ways: code 284 + 5 bits or code 285, so we
             // overwrite length_code[255] to use the best encoding:
@@ -1439,7 +1439,7 @@ gen_bitlen(tree_desc *desc)
     std::uint16_t f;                // frequency
     int overflow = 0;               // number of elements with bit length too large
 
-    std::fill(&bl_count_[0], &bl_count_[maxBits+1], 0);
+    std::fill(&bl_count_[0], &bl_count_[maxBits+1], std::uint16_t{0});
 
     /* In a first pass, compute the optimal bit lengths (which may
      * overflow in the case of the bit length tree).
@@ -1618,7 +1618,7 @@ scan_tree(
     int prevlen = -1;           // last emitted length
     int curlen;                 // length of current code
     int nextlen = tree[0].dl;   // length of next code
-    int count = 0;              // repeat count of the current code
+    std::uint16_t count = 0;    // repeat count of the current code
     int max_count = 7;          // max repeat count
     int min_count = 4;          // min repeat count
 
@@ -2629,8 +2629,8 @@ f_fast(z_params& zs, Flush flush) ->
         }
         if(match_length_ >= minMatch)
         {
-            tr_tally_dist(strstart_ - match_start_,
-                           match_length_ - minMatch, bflush);
+            tr_tally_dist(static_cast<std::uint16_t>(strstart_ - match_start_),
+                static_cast<std::uint8_t>(match_length_ - minMatch), bflush);
 
             lookahead_ -= match_length_;
 
@@ -2765,8 +2765,9 @@ f_slow(z_params& zs, Flush flush) ->
             /* Do not insert strings in hash table beyond this. */
             uInt max_insert = strstart_ + lookahead_ - minMatch;
 
-            tr_tally_dist(strstart_ -1 - prev_match_,
-                           prev_length_ - minMatch, bflush);
+            tr_tally_dist(
+                static_cast<std::uint16_t>(strstart_ -1 - prev_match_),
+                static_cast<std::uint8_t>(prev_length_ - minMatch), bflush);
 
             /* Insert in hash table all strings up to the end of the match.
              * strstart-1 and strstart are already inserted. If there is not
@@ -2890,7 +2891,9 @@ f_rle(z_params& zs, Flush flush) ->
 
         /* Emit match if have run of minMatch or longer, else emit literal */
         if(match_length_ >= minMatch) {
-            tr_tally_dist(1, match_length_ - minMatch, bflush);
+            tr_tally_dist(std::uint16_t{1},
+                static_cast<std::uint8_t>(match_length_ - minMatch),
+                bflush);
 
             lookahead_ -= match_length_;
             strstart_ += match_length_;

--- a/include/beast/zlib/detail/inflate_stream.hpp
+++ b/include/beast/zlib/detail/inflate_stream.hpp
@@ -1067,10 +1067,10 @@ get_fixed_tables() ->
             std::uint16_t lens[320];
             std::uint16_t work[288];
 
-            std::fill(&lens[  0], &lens[144], 8);
-            std::fill(&lens[144], &lens[256], 9);
-            std::fill(&lens[256], &lens[280], 7);
-            std::fill(&lens[280], &lens[288], 8);
+            std::fill(&lens[  0], &lens[144], std::uint16_t{8});
+            std::fill(&lens[144], &lens[256], std::uint16_t{9});
+            std::fill(&lens[256], &lens[280], std::uint16_t{7});
+            std::fill(&lens[280], &lens[288], std::uint16_t{8});
 
             {
                 error_code ec;
@@ -1090,7 +1090,7 @@ get_fixed_tables() ->
             {
                 error_code ec;
                 auto next = &dist_[0];
-                std::fill(&lens[0], &lens[32], 5);
+                std::fill(&lens[0], &lens[32], std::uint16_t{5});
                 inflate_table(build::dists,
                     lens, 32, &next, &distbits, work, ec);
                 if(ec)

--- a/test/benchmarks/buffers.cpp
+++ b/test/benchmarks/buffers.cpp
@@ -71,7 +71,7 @@ public:
             std::fill(
                 buffer_cast<char*>(buffer),
                 buffer_cast<char*>(buffer) +
-                    buffer_size(buffer), 0);
+                    buffer_size(buffer), '\0');
             n += buffer_size(buffer);
         }
         return n;

--- a/test/benchmarks/nodejs_parser.hpp
+++ b/test/benchmarks/nodejs_parser.hpp
@@ -768,31 +768,30 @@ private:
     }
 
     void
-    on_field(std::string const& field, std::string const& value)
+    on_field(std::string const&, std::string const&)
     {
     }
 
     void
-    on_headers_complete(error_code&)
+    on_headers_complete(error_code& ec)
     {
         // vFALCO TODO Decode the Content-Length and
         // Transfer-Encoding, see if we can reserve the buffer.
         //
         // r_.reserve(content_length)
+        ec.assign(0, ec.category());
     }
 
     bool
-    on_request(unsigned method, std::string const& url,
-        int major, int minor, bool /*keep_alive*/, bool /*upgrade*/,
-            std::true_type)
+    on_request(unsigned, std::string const&,
+        int, int, bool, bool, std::true_type)
     {
         return true;
     }
 
     bool
     on_request(unsigned, std::string const&,
-        int, int, bool, bool,
-            std::false_type)
+        int, int, bool, bool, std::false_type)
     {
         return true;
     }
@@ -808,11 +807,9 @@ private:
     }
 
     bool
-    on_response(int status, std::string const& reason,
-        int major, int minor, bool keep_alive, bool upgrade,
-            std::true_type)
+    on_response(int, std::string const&,
+        int, int, bool, bool, std::true_type)
     {
-        beast::detail::ignore_unused(keep_alive, upgrade);
         return true;
     }
 
@@ -833,9 +830,9 @@ private:
     }
 
     void
-    on_body(void const* data,
-        std::size_t size, error_code& ec)
+    on_body(void const*, std::size_t, error_code& ec)
     {
+        ec.assign(0, ec.category());
     }
 
     void

--- a/test/http/message.cpp
+++ b/test/http/message.cpp
@@ -160,7 +160,7 @@ public:
             other.moved_from = true;
         }
 
-        MoveFields& operator=(MoveFields&& other)
+        MoveFields& operator=(MoveFields&&)
         {
             return *this;
         }

--- a/test/http/test_parser.hpp
+++ b/test/http/test_parser.hpp
@@ -79,7 +79,7 @@ public:
     }
 
     void
-    on_field(field f, string_view,
+    on_field(field, string_view,
         string_view, error_code& ec)
     {
         got_on_field = true;

--- a/test/http/write.cpp
+++ b/test/http/write.cpp
@@ -678,7 +678,7 @@ public:
         isRequest, Body, Fields> const& m, error_code& ec,
             Decorator const& decorator = Decorator{})
     {
-        serializer<isRequest, Body, Fields, Decorator> sr{m};
+        serializer<isRequest, Body, Fields, Decorator> sr{m, decorator};
         for(;;)
         {
             stream.nwrite = 0;
@@ -700,7 +700,7 @@ public:
             error_code& ec, yield_context yield,
                 Decorator const& decorator = Decorator{})
     {
-        serializer<isRequest, Body, Fields, Decorator> sr{m};
+        serializer<isRequest, Body, Fields, Decorator> sr{m, decorator};
         for(;;)
         {
             stream.nwrite = 0;

--- a/test/websocket/doc_snippets.cpp
+++ b/test/websocket/doc_snippets.cpp
@@ -191,6 +191,7 @@ boost::asio::ip::tcp::socket sock{ios};
         [](bool is_pong, ping_data const& payload)
         {
             // Do something with the payload
+            boost::ignore_unused(is_pong, payload);
         });
 //]
 

--- a/test/websocket/utf8_checker.cpp
+++ b/test/websocket/utf8_checker.cpp
@@ -49,7 +49,7 @@ public:
                 BEAST_EXPECT(! utf8.write(&(*it), 1));
 
         // Invalid sequence
-        std::fill(buf.begin(), buf.end(), 0xFF);
+        std::fill(buf.begin(), buf.end(), '\xff');
         BEAST_EXPECT(! utf8.write(&buf.front(), buf.size()));
     }
 


### PR DESCRIPTION
* Enable narrowing warning on msvc cmake
* Fix integer types in deflate_stream::bi_reverse
* Fix narrowing in static_ostream
* Fix narrowing in ostream
* Fix narrowing in inflate_stream
* Fix narrowing in deflate_stream
* Fix integer warnings
* Enable unused variable warning on msvc cmake
