### PR TITLE
Bug fixed in file_service.hpp

### DIFF
--- a/example/server-framework/file_service.hpp
+++ b/example/server-framework/file_service.hpp
@@ -157,7 +157,7 @@ public:
             boost::filesystem::path full_path = root_ / rel_path;
 
             // Make sure the file is there
-            if(! boost::filesystem::exists(full_path))
+            if(boost::filesystem::exists(full_path))
             {
                 // Send a HEAD response
                 send(head(req, full_path));


### PR DESCRIPTION
```
            // Make sure the file is there
            if(! boost::filesystem::exists(full_path))
            {
                // Send a HEAD response
                send(head(req, full_path));
            }
            else
            {
                // Send a Not Found result
                send(not_found(req, rel_path));
            }
```

==>

```
            // Make sure the file is there
            if(boost::filesystem::exists(full_path))
            {
                // Send a HEAD response
                send(head(req, full_path));
            }
            else
            {
                // Send a Not Found result
                send(not_found(req, rel_path));
            }
```