### PR TITLE
Fix Beast include directories for cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,9 +148,9 @@ target_link_libraries (${PROJECT_NAME} INTERFACE ${Boost_SYSTEM_LIBRARY})
 if (NOT MSVC)
     target_link_libraries (${PROJECT_NAME} INTERFACE Threads::Threads)
 endif()
-set_property (TARGET ${PROJECT_NAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
-set_property (TARGET ${PROJECT_NAME} PROPERTY  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
 target_compile_definitions (${PROJECT_NAME} INTERFACE BOOST_COROUTINES_NO_DEPRECATION_WARNING=1)
+target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
 
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Using CMake, Beast does not seem to have an install target (`cmake beast && make -j$(nproc) && make install` will not install anything). That might be handy to add somewhere if you intend to keep it useable separate from Boost's bjam.

I tried copying the example/server-framework to its own CMake project, added Beast as a git submodule, and asked cmake to `add_subdirectory(beast)`. Adding separate projects in this fashion is actually an anti-pattern, but it's a common one. It almost worked... there's a bug with Beast's include directory specification, resolving it is the purpose of this pull request.

It appears that the Boost libraries' include directories were specified twice and the local include directory was not specified at all.

```
In file included from beast-test/src/http_async_port.hpp:13:0,
                 from beast-test/src/main.cpp:10:
beast-test/src/http_base.hpp:11:33: fatal error: beast/core/string.hpp: No such file or directory
 #include <beast/core/string.hpp>
                                 ^
compilation terminated.
```

To highlight, I created https://github.com/inetknght/beast-test
You can copy-paste from the README.md into a Linux environment (I'm using GCC 6.3, Fedora 25, cmake 3.7, and Boost 1.62)

I am quite curious if there's already an existing repository with a better laid out example of how to use beast as a cmake dependency?