### PR TITLE
removed redundant flush() from example

### DIFF
--- a/example/http-client/http_client.cpp
+++ b/example/http-client/http_client.cpp
@@ -25,7 +25,6 @@ int main()
         [](std::string what, beast::error_code ec)
         {
             std::cerr << what << ": " << ec.message() << std::endl;
-            std::cerr.flush();
             return EXIT_FAILURE;
         };
 


### PR DESCRIPTION
`<<std::endl` already flushes the stream; no need for a separate call.