### PR TITLE
Version 75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 75:
 * Tidy up BEAST_NO_BIG_VARIANTS
 * Shrink serializer buffers using buffers_ref
 * Add serializer::limit
+* file_body tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 75:
 
 * Use file_body for valid requests, string_body otherwise.
+* Construct buffer_prefix_view in-place
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Version 75:
 
 * Use file_body for valid requests, string_body otherwise.
 * Construct buffer_prefix_view in-place
+* Shrink serializer buffers using buffers_ref
+* Tidy up BEAST_NO_BIG_VARIANTS
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 75:
+
+* Use file_body for valid requests, string_body otherwise.
+
+--------------------------------------------------------------------------------
+
 Version 74:
 
 * Add file_stdio and File concept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 75:
 * Shrink serializer buffers using buffers_ref
 * Tidy up BEAST_NO_BIG_VARIANTS
 * Shrink serializer buffers using buffers_ref
+* Add serializer::limit
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 75:
 * Construct buffer_prefix_view in-place
 * Shrink serializer buffers using buffers_ref
 * Tidy up BEAST_NO_BIG_VARIANTS
+* Shrink serializer buffers using buffers_ref
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 75:
 * Shrink serializer buffers using buffers_ref
 * Add serializer::limit
 * file_body tests
+* Using SSE4.2 intrinsics in basic_parser if available
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 74)
+project (Beast VERSION 75)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/example/http-server-fast/http_server_fast.cpp
+++ b/example/http-server-fast/http_server_fast.cpp
@@ -71,11 +71,17 @@ private:
     boost::asio::basic_waitable_timer<std::chrono::steady_clock> request_deadline_{
         acceptor_.get_io_service(), (std::chrono::steady_clock::time_point::max)()};
 
-    // The response message.
-    boost::optional<http::response<http::string_body, http::basic_fields<alloc_t>>> response_;
+    // The string-based response message.
+    boost::optional<http::response<http::string_body, http::basic_fields<alloc_t>>> string_response_;
 
-    // The response serializer.
-    boost::optional<http::response_serializer<http::string_body, http::basic_fields<alloc_t>>> serializer_;
+    // The string-based response serializer.
+    boost::optional<http::response_serializer<http::string_body, http::basic_fields<alloc_t>>> string_serializer_;
+
+    // The file-based response message.
+    boost::optional<http::response<http::file_body, http::basic_fields<alloc_t>>> file_response_;
+
+    // The file-based response serializer.
+    boost::optional<http::response_serializer<http::file_body, http::basic_fields<alloc_t>>> file_serializer_;
 
     void accept()
     {
@@ -136,77 +142,104 @@ private:
 
     void process_request(http::request<request_body_t, http::basic_fields<alloc_t>> const& req)
     {
-        response_.emplace(
-            std::piecewise_construct,
-            std::make_tuple(),
-            std::make_tuple(alloc_));
-
-        response_->set(http::field::connection, "close");
-
         switch (req.method())
         {
         case http::verb::get:
-            response_->result(http::status::ok);
-            response_->set(http::field::server, "Beast");
-            load_file(req.target());
+            send_file(req.target());
             break;
 
         default:
             // We return responses indicating an error if
             // we do not recognize the request method.
-            response_->result(http::status::bad_request);
-            response_->set(http::field::content_type, "text/plain");
-            response_->body = "Invalid request-method '" + req.method_string().to_string() + "'";
+            send_bad_response(
+                http::status::bad_request,
+                "Invalid request-method '" + req.method_string().to_string() + "'\r\n");
             break;
         }
-
-        write_response();
     }
 
-    void load_file(beast::string_view target)
+    void send_bad_response(
+        http::status status,
+        std::string const& error)
+    {
+        string_response_.emplace(
+            std::piecewise_construct,
+            std::make_tuple(),
+            std::make_tuple(alloc_));
+
+        string_response_->result(status);
+        string_response_->set(http::field::server, "Beast");
+        string_response_->set(http::field::connection, "close");
+        string_response_->set(http::field::content_type, "text/plain");
+        string_response_->body = error;
+        string_response_->prepare_payload();
+
+        string_serializer_.emplace(*string_response_);
+
+        http::async_write(
+            socket_,
+            *string_serializer_,
+            [this](beast::error_code ec)
+            {
+                socket_.shutdown(tcp::socket::shutdown_send, ec);
+                string_serializer_.reset();
+                string_response_.reset();
+                accept();
+            });
+    }
+
+    void send_file(beast::string_view target)
     {
         // Request path must be absolute and not contain "..".
         if (target.empty() || target[0] != '/' || target.find("..") != std::string::npos)
         {
-            response_->result(http::status::not_found);
-            response_->set(http::field::content_type, "text/plain");
-            response_->body = "File not found\r\n";
+            send_bad_response(
+                http::status::not_found,
+                "File not found\r\n");
             return;
         }
 
         std::string full_path = doc_root_;
-        full_path.append(target.data(), target.size());
+        full_path.append(
+            target.data(),
+            target.size());
 
-        // Open the file to send back.
-        std::ifstream is(full_path.c_str(), std::ios::in | std::ios::binary);
-        if (!is)
+        http::file_body::value_type file;
+        beast::error_code ec;
+        file.open(
+            full_path.c_str(),
+            beast::file_mode::read,
+            ec);
+        if(ec)
         {
-            response_->result(http::status::not_found);
-            response_->set(http::field::content_type, "text/plain");
-            response_->body = "File not found\r\n";
+            send_bad_response(
+                http::status::not_found,
+                "File not found\r\n");
             return;
         }
 
-        // Fill out the reply to be sent to the client.
-        response_->set(http::field::content_type, mime_type(target.to_string()));
-        response_->body.clear();
-        for (char buf[2048]; is.read(buf, sizeof(buf)).gcount() > 0;)
-            response_->body.append(buf, static_cast<std::size_t>(is.gcount()));
-    }
+        file_response_.emplace(
+            std::piecewise_construct,
+            std::make_tuple(),
+            std::make_tuple(alloc_));
 
-    void write_response()
-    {
-        response_->prepare_payload();
-        serializer_.emplace(*response_);
+        file_response_->result(http::status::ok);
+        file_response_->set(http::field::server, "Beast");
+        file_response_->set(http::field::connection, "close");
+        file_response_->set(http::field::content_type, mime_type(target.to_string()));
+        file_response_->body = std::move(file);
+        file_response_->prepare_payload();
+
+        file_serializer_.emplace(*file_response_);
 
         http::async_write(
             socket_,
-            *serializer_,
+            *file_serializer_,
             [this](beast::error_code ec)
             {
                 socket_.shutdown(tcp::socket::shutdown_send, ec);
-                serializer_.reset();
-                response_.reset();
+                file_serializer_.reset();
+                file_response_.reset();
                 accept();
             });
     }

--- a/include/beast/core/buffer_prefix.hpp
+++ b/include/beast/core/buffer_prefix.hpp
@@ -28,8 +28,10 @@ namespace beast {
 template<class BufferSequence>
 class buffer_prefix_view
 {
-    using iter_type =
-        typename BufferSequence::const_iterator;
+    using buffers_type = typename
+        std::decay<BufferSequence>::type;
+
+    using iter_type = typename buffers_type::const_iterator;
 
     BufferSequence bs_;
     iter_type back_;

--- a/include/beast/core/buffer_prefix.hpp
+++ b/include/beast/core/buffer_prefix.hpp
@@ -10,6 +10,7 @@
 
 #include <beast/config.hpp>
 #include <beast/core/type_traits.hpp>
+#include <beast/core/detail/in_place_init.hpp>
 #include <boost/asio/buffer.hpp>
 #include <cstdint>
 #include <type_traits>
@@ -78,18 +79,31 @@ public:
     /// Copy assignment.
     buffer_prefix_view& operator=(buffer_prefix_view const&);
 
-    /** Construct a shortened buffer sequence.
+    /** Construct a buffer sequence prefix.
 
-        @param n The maximum number of bytes in the wrapped
-        sequence. If this is larger than the size of passed,
-        buffers, the resulting sequence will represent the
-        entire input sequence.
+        @param n The maximum number of bytes in the prefix.
+        If this is larger than the size of passed, buffers,
+        the resulting sequence will represent the entire
+        input sequence.
 
         @param buffers The buffer sequence to adapt. A copy of
         the sequence will be made, but ownership of the underlying
         memory is not transferred.
     */
     buffer_prefix_view(std::size_t n, BufferSequence const& buffers);
+
+    /** Construct a buffer sequence prefix in-place.
+
+        @param n The maximum number of bytes in the prefix.
+        If this is larger than the size of passed, buffers,
+        the resulting sequence will represent the entire
+        input sequence.
+
+        @param args Arguments forwarded to the contained buffers constructor.
+    */
+    template<class... Args>
+    buffer_prefix_view(std::size_t n,
+        boost::in_place_init_t, Args&&... args);
 
     /// Get a bidirectional iterator to the first element.
     const_iterator

--- a/include/beast/core/detail/buffers_ref.hpp
+++ b/include/beast/core/detail/buffers_ref.hpp
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BEAST_DETAIL_BUFFERS_REF_HPP
+#define BEAST_DETAIL_BUFFERS_REF_HPP
+
+#include <beast/core/type_traits.hpp>
+
+namespace beast {
+namespace detail {
+
+// A very lightweight reference to a buffer sequence
+template<class BufferSequence>
+class buffers_ref
+{
+    BufferSequence const& buffers_;
+
+public:
+    using value_type =
+        typename BufferSequence::value_type;
+
+    using const_iterator =
+        typename BufferSequence::const_iterator;
+
+    buffers_ref(buffers_ref const&) = default;
+
+    explicit
+    buffers_ref(BufferSequence const& buffers)
+        : buffers_(buffers)
+    {
+    }
+
+    const_iterator
+    begin() const
+    {
+        return buffers_.begin();
+    }
+
+    const_iterator
+    end() const
+    {
+        return buffers_.end();
+    }
+};
+
+// Return a reference to a buffer sequence
+template<class BufferSequence>
+buffers_ref<BufferSequence>
+make_buffers_ref(BufferSequence const& buffers)
+{
+    return buffers_ref<BufferSequence>(buffers);
+}
+
+} // detail
+} // beast
+
+#endif

--- a/include/beast/core/detail/cpu_info.hpp
+++ b/include/beast/core/detail/cpu_info.hpp
@@ -8,11 +8,10 @@
 #ifndef BEAST_DETAIL_CPU_INFO_HPP
 #define BEAST_DETAIL_CPU_INFO_HPP
 
+#include <boost/config.hpp>
+
 #ifndef BEAST_NO_INTRINSICS
-# if defined(_MSC_VER) || \
-    (defined(__i386__) && defined(__PIC__) && \
-     defined(__GNUC__) && ! defined(__clang__)) || \
-    defined(__i386__)
+# if defined(BOOST_MSVC) || ((defined(BOOST_GCC) || defined(BOOST_CLANG)) && defined(__SSE4_2__))
 #  define BEAST_NO_INTRINSICS 0
 # else
 #  define BEAST_NO_INTRINSICS 1
@@ -21,8 +20,10 @@
 
 #if ! BEAST_NO_INTRINSICS
 
-#if defined(_MSC_VER)
+#if defined(BOOST_MSVC)
 #include <intrin.h> // __cpuid
+#else
+#include <cpuid.h>  // __get_cpuid
 #endif
 
 namespace beast {
@@ -40,34 +41,15 @@ cpuid(
     std::uint32_t& ecx,
     std::uint32_t& edx)
 {
-#if defined(_MSC_VER)
+#if defined(BOOST_MSVC)
     int regs[4];
     __cpuid(regs, id);
     eax = regs[0];
     ebx = regs[1];
     ecx = regs[2];
     edx = regs[3];
-
-#elif defined(__i386__) && defined(__PIC__) && \
-      defined(__GNUC__) && ! defined(__clang__)
-    // We have to backup ebx in 32 bit PIC code because it is reserved by the ABI
-    uint32_t ebx_backup;
-    __asm__ __volatile__
-    (
-        "movl %%ebx, %0\n\t"
-        "movl %1, %%ebx\n\t"
-        "cpuid\n\t"
-        "movl %%ebx, %1\n\t"
-        "movl %0, %%ebx\n\t"
-            : "=m" (ebx_backup), "+m"(ebx), "+a"(eax), "+c"(ecx), "+d"(edx)
-    );
-
-#elif defined(__i386__)
-    __asm__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(id) : "ebx");
-
 #else
-# error Unknown compiler!
-
+    __get_cpuid(id, &eax, &ebx, &ecx, &edx);
 #endif
 }
 
@@ -82,13 +64,18 @@ inline
 cpu_info::
 cpu_info()
 {
-    std::uint32_t eax, ebx, ecx, edx;
+    constexpr std::uint32_t SSE42 = 1 << 20;
+
+    std::uint32_t eax = 0;
+    std::uint32_t ebx = 0;
+    std::uint32_t ecx = 0;
+    std::uint32_t edx = 0;
 
     cpuid(0, eax, ebx, ecx, edx);
     if(eax >= 1)
     {
         cpuid(1, eax, ebx, ecx, edx);
-        sse42 = (ecx & (1 << 20)) != 0;
+        sse42 = (ecx & SSE42) != 0;
     }
 }
 

--- a/include/beast/core/detail/in_place_init.hpp
+++ b/include/beast/core/detail/in_place_init.hpp
@@ -9,6 +9,7 @@
 #define BEAST_DETAIL_IN_PLACE_INIT_HPP
 
 #include <boost/version.hpp>
+#include <boost/optional/optional.hpp>
 
 // Provide boost::in_place_init_t and boost::in_place_init
 // for Boost versions earlier than 1.63.0.

--- a/include/beast/core/file.hpp
+++ b/include/beast/core/file.hpp
@@ -22,7 +22,9 @@ namespace beast {
     of @b File given the platform and build settings.
 */
 #if BEAST_DOXYGEN
-using file = implementation_defined;
+struct file : file_stdio
+{
+};
 #else
 #if BEAST_USE_WIN32_FILE
 using file = file_win32;

--- a/include/beast/core/file_posix.hpp
+++ b/include/beast/core/file_posix.hpp
@@ -32,9 +32,9 @@
 
 namespace beast {
 
-/** An implementation of File for Win32.
+/** An implementation of File for POSIX systems.
 
-    This class implements a @b File using Win32 native interfaces.
+    This class implements a @b File using POSIX interfaces.
 */
 class file_posix
 {

--- a/include/beast/core/impl/buffer_prefix.ipp
+++ b/include/beast/core/impl/buffer_prefix.ipp
@@ -48,11 +48,8 @@ class buffer_prefix_view<BufferSequence>::const_iterator
 {
     friend class buffer_prefix_view<BufferSequence>;
 
-    using iter_type =
-        typename BufferSequence::const_iterator;
-
     buffer_prefix_view const* b_ = nullptr;
-    typename BufferSequence::const_iterator it_;
+    iter_type it_;
 
 public:
     using value_type = typename std::conditional<

--- a/include/beast/core/impl/buffer_prefix.ipp
+++ b/include/beast/core/impl/buffer_prefix.ipp
@@ -157,7 +157,8 @@ setup(std::size_t n)
 }
 
 template<class BufferSequence>
-buffer_prefix_view<BufferSequence>::const_iterator::
+buffer_prefix_view<BufferSequence>::
+const_iterator::
 const_iterator(const_iterator&& other)
     : b_(other.b_)
     , it_(std::move(other.it_))
@@ -165,7 +166,8 @@ const_iterator(const_iterator&& other)
 }
 
 template<class BufferSequence>
-buffer_prefix_view<BufferSequence>::const_iterator::
+buffer_prefix_view<BufferSequence>::
+const_iterator::
 const_iterator(const_iterator const& other)
     : b_(other.b_)
     , it_(other.it_)
@@ -174,7 +176,8 @@ const_iterator(const_iterator const& other)
 
 template<class BufferSequence>
 auto
-buffer_prefix_view<BufferSequence>::const_iterator::
+buffer_prefix_view<BufferSequence>::
+const_iterator::
 operator=(const_iterator&& other) ->
     const_iterator&
 {
@@ -185,7 +188,8 @@ operator=(const_iterator&& other) ->
 
 template<class BufferSequence>
 auto
-buffer_prefix_view<BufferSequence>::const_iterator::
+buffer_prefix_view<BufferSequence>::
+const_iterator::
 operator=(const_iterator const& other) ->
     const_iterator&
 {
@@ -252,6 +256,16 @@ template<class BufferSequence>
 buffer_prefix_view<BufferSequence>::
 buffer_prefix_view(std::size_t n, BufferSequence const& bs)
     : bs_(bs)
+{
+    setup(n);
+}
+
+template<class BufferSequence>
+template<class... Args>
+buffer_prefix_view<BufferSequence>::
+buffer_prefix_view(std::size_t n,
+        boost::in_place_init_t, Args&&... args)
+    : bs_(std::forward<Args>(args)...)
 {
     setup(n);
 }

--- a/include/beast/http/impl/serializer.ipp
+++ b/include/beast/http/impl/serializer.ipp
@@ -8,6 +8,7 @@
 #ifndef BEAST_HTTP_IMPL_SERIALIZER_IPP
 #define BEAST_HTTP_IMPL_SERIALIZER_IPP
 
+#include <beast/core/detail/buffers_ref.hpp>
 #include <beast/http/error.hpp>
 #include <beast/http/status.hpp>
 #include <beast/core/detail/config.hpp>
@@ -53,6 +54,7 @@ serializer<isRequest, Body, Fields, ChunkDecorator>::
 next(error_code& ec, Visit&& visit)
 {
     using boost::asio::buffer_size;
+    using beast::detail::make_buffers_ref;
     switch(s_)
     {
     case do_construct:
@@ -90,14 +92,16 @@ next(error_code& ec, Visit&& visit)
     }
 
     case do_header:
-        visit(ec, boost::get<cb0_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<cb0_t>(v_)));
         break;
 
     go_header_only:
         v_ = ch_t{frd_->get()};
         s_ = do_header_only;
     case do_header_only:
-        visit(ec, boost::get<ch_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch_t>(v_)));
         break;
 
     case do_body:
@@ -124,7 +128,8 @@ next(error_code& ec, Visit&& visit)
     }
 
     case do_body + 2:
-        visit(ec, boost::get<cb1_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<cb1_t>(v_)));
         break;
 
     //----------------------------------------------------------------------
@@ -198,14 +203,16 @@ next(error_code& ec, Visit&& visit)
     }
 
     case do_header_c:
-        visit(ec, boost::get<ch0_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch0_t>(v_)));
         break;
 
     go_header_only_c:
         v_ = ch_t{frd_->get()};
         s_ = do_header_only_c;
     case do_header_only_c:
-        visit(ec, boost::get<ch_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch_t>(v_)));
         break;
 
     case do_body_c:
@@ -276,20 +283,23 @@ next(error_code& ec, Visit&& visit)
     }
 
     case do_body_c + 2:
-        visit(ec, boost::get<ch1_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch1_t>(v_)));
         break;
 
 #ifndef BEAST_NO_BIG_VARIANTS
     go_body_final_c:
         s_ = do_body_final_c;
     case do_body_final_c:
-        visit(ec, boost::get<ch2_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch2_t>(v_)));
         break;
 
     go_all_c:
         s_ = do_all_c;
     case do_all_c:
-        visit(ec, boost::get<ch3_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch3_t>(v_)));
         break;
 #endif
 
@@ -311,7 +321,8 @@ next(error_code& ec, Visit&& visit)
         BEAST_FALLTHROUGH;
 
     case do_final_c + 1:
-        visit(ec, boost::get<ch4_t>(v_));
+        visit(ec, make_buffers_ref(
+            boost::get<ch4_t>(v_)));
         break;
 
     //----------------------------------------------------------------------

--- a/include/beast/http/impl/serializer.ipp
+++ b/include/beast/http/impl/serializer.ipp
@@ -146,7 +146,7 @@ next(error_code& ec, Visit&& visit)
         if(! result)
             goto go_header_only_c;
         more_ = result->second;
-    #if ! BEAST_NO_BIG_VARIANTS
+    #ifndef BEAST_NO_BIG_VARIANTS
         if(! more_)
         {
             // do it all in one buffer
@@ -226,7 +226,7 @@ next(error_code& ec, Visit&& visit)
         if(! result)
             goto go_final_c;
         more_ = result->second;
-    #if ! BEAST_NO_BIG_VARIANTS
+    #ifndef BEAST_NO_BIG_VARIANTS
         if(! more_)
         {
             // do it all in one buffer
@@ -279,7 +279,7 @@ next(error_code& ec, Visit&& visit)
         visit(ec, boost::get<ch1_t>(v_));
         break;
 
-#if ! BEAST_NO_BIG_VARIANTS
+#ifndef BEAST_NO_BIG_VARIANTS
     go_body_final_c:
         s_ = do_body_final_c;
     case do_body_final_c:
@@ -423,7 +423,7 @@ consume(std::size_t n)
             s_ = do_final_c;
         break;
 
-#if ! BEAST_NO_BIG_VARIANTS
+#ifndef BEAST_NO_BIG_VARIANTS
     case do_body_final_c:
     {
         auto& b = boost::get<ch2_t>(v_);

--- a/include/beast/http/impl/write.ipp
+++ b/include/beast/http/impl/write.ipp
@@ -54,12 +54,12 @@ class write_some_op
         template<class ConstBufferSequence>
         void
         operator()(error_code& ec,
-            ConstBufferSequence const& buffer)
+            ConstBufferSequence const& buffers)
         {
             ec.assign(0, ec.category());
             invoked = true;
             return op_.s_.async_write_some(
-                buffer, std::move(op_));
+                buffers, std::move(op_));
         }
     };
 
@@ -211,12 +211,12 @@ class write_op
         template<class ConstBufferSequence>
         void
         operator()(error_code& ec,
-            ConstBufferSequence const& buffer)
+            ConstBufferSequence const& buffers)
         {
             ec.assign(0, ec.category());
             invoked = true;
             return op_.s_.async_write_some(
-                buffer, std::move(op_));
+                buffers, std::move(op_));
         }
     };
 
@@ -464,11 +464,11 @@ public:
     template<class ConstBufferSequence>
     void
     operator()(error_code& ec,
-        ConstBufferSequence const& buffer)
+        ConstBufferSequence const& buffers)
     {
         invoked = true;
         bytes_transferred =
-            stream_.write_some(buffer, ec);
+            stream_.write_some(buffers, ec);
     }
 };
 
@@ -490,11 +490,11 @@ public:
     template<class ConstBufferSequence>
     void
     operator()(error_code& ec,
-        ConstBufferSequence const& buffer)
+        ConstBufferSequence const& buffers)
     {
         invoked = true;
         bytes_transferred = boost::asio::write(
-            stream_, buffer, ec);
+            stream_, buffers, ec);
     }
 };
 

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -21,9 +21,7 @@
 
 #ifndef BEAST_NO_BIG_VARIANTS
 # if defined(BOOST_GCC) && BOOST_GCC < 50000 && BOOST_VERSION < 106400
-#  define BEAST_NO_BIG_VARIANTS 1
-# else
-#  define BEAST_NO_BIG_VARIANTS 0
+#  define BEAST_NO_BIG_VARIANTS
 # endif
 #endif
 
@@ -148,7 +146,7 @@ class serializer
         do_header_c         =  70,
         do_body_c           =  80,
         do_final_c          =  90,
-    #if ! BEAST_NO_BIG_VARIANTS
+    #ifndef BEAST_NO_BIG_VARIANTS
         do_body_final_c     = 100,
         do_all_c            = 110,
     #endif
@@ -186,7 +184,7 @@ class serializer
         typename reader::const_buffers_type,        // body
         boost::asio::const_buffers_1>>;             // crlf
 
-#if ! BEAST_NO_BIG_VARIANTS
+#ifndef BEAST_NO_BIG_VARIANTS
     using ch2_t = consuming_buffers<buffer_cat_view<
         detail::chunk_header,                       // chunk-header
         boost::asio::const_buffers_1,               // chunk-ext
@@ -219,7 +217,7 @@ class serializer
     boost::optional<reader> rd_;
     boost::variant<boost::blank,
         ch_t, cb0_t, cb1_t, ch0_t, ch1_t
-    #if ! BEAST_NO_BIG_VARIANTS
+    #ifndef BEAST_NO_BIG_VARIANTS
         ,ch2_t, ch3_t
     #endif
         , ch4_t> v_;

--- a/include/beast/version.hpp
+++ b/include/beast/version.hpp
@@ -18,7 +18,7 @@
     This is a simple integer that is incremented by one every time
     a set of code changes is merged to the master or develop branch.
 */
-#define BEAST_VERSION 74
+#define BEAST_VERSION 75
 
 #define BEAST_VERSION_STRING "Beast/" BOOST_STRINGIZE(BEAST_VERSION)
 

--- a/test/http/file_body.cpp
+++ b/test/http/file_body.cpp
@@ -97,6 +97,12 @@ public:
     run() override
     {
         doTestFileBody<file_stdio>();
+    #if BEAST_USE_WIN32_FILE
+        doTestFileBody<file_win32>();
+    #endif
+    #if BEAST_USE_POSIX_FILE
+        doTestFileBody<file_posix>();
+    #endif
     }
 };
 

--- a/test/http/serializer.cpp
+++ b/test/http/serializer.cpp
@@ -7,3 +7,57 @@
 
 // Test that header file is self-contained.
 #include <beast/http/serializer.hpp>
+
+#include <beast/http/string_body.hpp>
+#include <beast/unit_test/suite.hpp>
+
+namespace beast {
+namespace http {
+
+class serializer_test : public beast::unit_test::suite
+{
+public:
+    struct lambda
+    {
+        std::size_t size;
+
+        template<class ConstBufferSequence>
+        void
+        operator()(error_code&,
+            ConstBufferSequence const& buffers)
+        {
+            size = boost::asio::buffer_size(buffers);
+        }
+    };
+
+    void
+    testWriteLimit()
+    {
+        auto const limit = 30;
+        lambda visit;
+        error_code ec;
+        response<string_body> res;
+        res.body.append(1000, '*');
+        serializer<false, string_body> sr{res};
+        sr.limit(limit);
+        for(;;)
+        {
+            sr.next(ec, visit);
+            BEAST_EXPECT(visit.size <= limit);
+            sr.consume(visit.size);
+            if(sr.is_done())
+                break;
+        }
+    }
+
+    void
+    run() override
+    {
+        testWriteLimit();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(serializer,http,beast);
+
+} // http
+} // beast


### PR DESCRIPTION
* Use file_body for valid requests, string_body otherwise.
* Construct buffer_prefix_view in-place
* Shrink serializer buffers using buffers_ref
* Tidy up BEAST_NO_BIG_VARIANTS
* Shrink serializer buffers using buffers_ref
* Add serializer::limit

Documentation preview:
http://vinniefalco.github.io/stage/beast/v75