### PR TITLE
Version 76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 76:
 * Add serializer::chunked
 * Serializer members are not const
 * serializing file_body is not const
+* Add file_body_win32
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 76:
 * Add serializer::get
 * Add serializer::chunked
 * Serializer members are not const
+* serializing file_body is not const
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 76:
+
+* Always go through write_some
+
+--------------------------------------------------------------------------------
+
 Version 75:
 
 * Use file_body for valid requests, string_body otherwise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 76:
 
 * Always go through write_some
+* Use Boost.Config
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 76:
 * BodyReader may construct from a non-const message
 * Add serializer::get
 * Add serializer::chunked
+* Serializer members are not const
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 76:
 * Always go through write_some
 * Use Boost.Config
 * BodyReader may construct from a non-const message
+* Add serializer::get
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 76:
 * Use Boost.Config
 * BodyReader may construct from a non-const message
 * Add serializer::get
+* Add serializer::chunked
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 76:
 * Serializer members are not const
 * serializing file_body is not const
 * Add file_body_win32
+* Fix parse illegal characters in obs-fold
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 76:
 
 * Always go through write_some
 * Use Boost.Config
+* BodyReader may construct from a non-const message
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Version 76:
 * Add serializer::get
 * Add serializer::chunked
 
+API Changes:
+
+* Rename to serializer::keep_alive
+
+Actions Required:
+
+* Use serializer::keep_alive instead of serializer::close and
+  take the logical NOT of the return value.
+
 --------------------------------------------------------------------------------
 
 Version 75:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ Version 76:
 API Changes:
 
 * Rename to serializer::keep_alive
+* BodyReader, BodyWriter use two-phase init
 
 Actions Required:
 
 * Use serializer::keep_alive instead of serializer::close and
   take the logical NOT of the return value.
+
+* Modify instances of user-defined BodyReader and BodyWriter
+  types to perfrom two-phase initialization, as per the
+  updated documented type requirements.
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 76:
 * serializing file_body is not const
 * Add file_body_win32
 * Fix parse illegal characters in obs-fold
+* Disable SSE4.2 optimizations
 
 API Changes:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 75)
+project (Beast VERSION 76)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/concept/BodyReader.qbk
+++ b/doc/concept/BodyReader.qbk
@@ -36,8 +36,14 @@ In this table:
 
 * `R<T>` is the type `boost::optional<std::pair<T, bool>>`.
 
-[table BodyReader requirements
-[[expression] [type] [semantics, pre/post-conditions]]
+[heading Associated Types]
+
+* __Body__
+* [link beast.ref.beast__http__is_body_reader `is_body_reader`]
+
+[heading  BodyReader requirements]
+[table Valid Expressions
+[[Expression] [Type] [Semantics, Pre/Post-conditions]]
 [
     [`X::const_buffers_type`]
     []
@@ -46,22 +52,33 @@ In this table:
         This is the type of buffer returned by `X::get`.
     ]
 ][
-    [`X(m,ec);`]
+    [`X(m);`]
     []
     [
         Constructible from `m`. The lifetime of `m` is guaranteed
         to end no earlier than after the `X` is destroyed.
+        The reader shall not access the contents of `m` before the
+        first call to `init`, permitting lazy construction of the
+        message.
+
         The constructor may optionally require that `m` is const, which
         has these consequences:
 
         * If `X` requires that `m` is a const reference, then serializers
         constructed for messages with this body type will also require a
-        `const` reference to a message, otherwise:
+        const reference to a message, otherwise:
 
         * If `X` requires that `m` is a non-const reference, then serializers
         constructed for messages with this body type will aso require
         a non-const reference to a message.
-
+    ]
+][
+    [`a.init(ec)`]
+    []
+    [
+        Called once to fully initialize the object before any calls to
+        `get`. The message body becomes valid before entering this function,
+        and remains valid until the reader is destroyed.
         The function will ensure that `!ec` is `true` if there was
         no error or set to the appropriate error code if there was one. 
     ]
@@ -69,9 +86,9 @@ In this table:
     [`a.get(ec)`]
     [`R<X::const_buffers_type>`]
     [
-        Called repeatedly after `init` succeeds. This function returns
-        `boost::none` if all buffers representing the body have been
-        returned in previous calls or if it sets `ec` to indicate an
+        Called one or more times after `init` succeeds. This function
+        returns `boost::none` if all buffers representing the body have
+        been returned in previous calls or if it sets `ec` to indicate an
         error. Otherwise, if there are buffers remaining the function
         should return a pair with the first element containing a non-zero
         length buffer sequence representing the next set of octets in
@@ -82,18 +99,18 @@ In this table:
         The function will ensure that `!ec` is `true` if there was
         no error or set to the appropriate error code if there was one. 
     ]
-][
-    [`is_body_reader<B>`]
-    [`std::true_type`]
-    [
-        An alias for `std::true_type` for `B`, otherwise an alias
-        for `std::false_type`.
-    ]
 ]
 ]
 
 [heading Exemplar]
 
 [concept_BodyReader]
+
+[heading Models]
+
+* [link beast.ref.beast__http__basic_dynamic_body.reader `basic_dynamic_body::reader`]
+* [link beast.ref.beast__http__basic_file_body__reader `basic_file_body::reader`]
+* [link beast.ref.beast__http__empty_body.reader `empty_body::reader`]
+* [link beast.ref.beast__http__string_body.reader `string_body::reader`]
 
 [endsect]

--- a/doc/concept/BodyReader.qbk
+++ b/doc/concept/BodyReader.qbk
@@ -29,7 +29,7 @@ In this table:
 
 * `a` denotes a value of type `X`.
 
-* `m` denotes a value of type `message const&` where
+* `m` denotes a possibly const value of type `message&` where
       `std::is_same<decltype(m.body), Body::value_type>:value == true`.
 
 * `ec` is a value of type [link beast.ref.beast__error_code `error_code&`].
@@ -51,6 +51,17 @@ In this table:
     [
         Constructible from `m`. The lifetime of `m` is guaranteed
         to end no earlier than after the `X` is destroyed.
+        The constructor may optionally require that `m` is const, which
+        has these consequences:
+
+        * If `X` requires that `m` is a const reference, then serializers
+        constructed for messages with this body type will also require a
+        `const` reference to a message, otherwise:
+
+        * If `X` requires that `m` is a non-const reference, then serializers
+        constructed for messages with this body type will aso require
+        a non-const reference to a message.
+
         The function will ensure that `!ec` is `true` if there was
         no error or set to the appropriate error code if there was one. 
     ]

--- a/doc/concept/BodyWriter.qbk
+++ b/doc/concept/BodyWriter.qbk
@@ -38,20 +38,40 @@ In this table:
 
 * `ec` is a value of type [link beast.ref.beast__error_code `error_code&`].
 
+[heading Associated Types]
+
+* __Body__
+* [link beast.ref.beast__http__is_body_writer `is_body_writer`]
+
 [table Writer requirements
 [[expression] [type] [semantics, pre/post-conditions]]
 [
-    [`X(m,n,ec);`]
+    [`X(m);`]
     []
     [
-        Constructible from `m`. The lifetime of `m` is guaranteed
-        to end no earlier than after the `X` is destroyed. The constructor
-        will be called after a complete header is stored in `m`, and before
-        parsing body octets for messages indicating that a body is present.
+        Constructible from `m`. The lifetime of `m` is guaranteed to
+        end no earlier than after the `X` is destroyed. The constructor
+        will be called after a complete header is stored in `m`, and
+        before parsing body octets for messages indicating that a body
+        is present The writer shall not access the contents of `m` before
+        the first call to `init`, permitting lazy construction of the
+        message.
+
+        The function will ensure that `!ec` is `true` if there was
+        no error or set to the appropriate error code if there was one. 
+    ]
+][
+    [`a.init(n, ec)`]
+    []
+    [
+        Called once to fully initialize the object before any calls to
+        `put`. The message body is valid before entering this function,
+        and remains valid until the writer is destroyed.
         The value of `n` will be set to the content length of the
         body if known, otherwise `n` will be equal to `boost::none`.
         Implementations of [*BodyWriter] may use this information to
         optimize allocation.
+
         The function will ensure that `!ec` is `true` if there was
         no error or set to the appropriate error code if there was one. 
     ]
@@ -88,5 +108,12 @@ In this table:
 [heading Exemplar]
 
 [concept_BodyWriter]
+
+[heading Models]
+
+* [link beast.ref.beast__http__basic_dynamic_body.writer `basic_dynamic_body::writer`]
+* [link beast.ref.beast__http__basic_file_body__reader `basic_file_body::writer`]
+* [link beast.ref.beast__http__empty_body.writer `empty_body::writer`]
+* [link beast.ref.beast__http__string_body.writer `string_body::writer`]
 
 [endsect]

--- a/example/common/const_body.hpp
+++ b/example/common/const_body.hpp
@@ -68,9 +68,14 @@ struct const_body
 
         template<bool isRequest, class Fields>
         explicit
-        reader(beast::http::message<isRequest, const_body,
-                Fields> const& msg, beast::error_code& ec)
+        reader(beast::http::message<isRequest,
+                const_body, Fields> const& msg)
             : body_(msg.body)
+        {
+        }
+
+        void
+        init(beast::error_code& ec)
         {
             ec.assign(0, ec.category());
         }

--- a/example/common/write_msg.hpp
+++ b/example/common/write_msg.hpp
@@ -46,12 +46,16 @@ class write_msg_op
         //
         beast::http::message<isRequest, Body, Fields> msg;
 
+        // Serializer for the message
+        beast::http::serializer<isRequest, Body, Fields> sr;
+
         data(
             Handler& handler,
             AsyncWriteStream& stream_,
             beast::http::message<isRequest, Body, Fields>&& msg_)
             : stream(stream_)
             , msg(std::move(msg_))
+            , sr(msg)
         {
             boost::ignore_unused(handler);
         }
@@ -96,7 +100,7 @@ public:
     {
         auto& d = *d_;
         beast::http::async_write(
-            d.stream, d.msg, std::move(*this));
+            d.stream, d.sr, std::move(*this));
     }
 
     // Completion handler

--- a/example/http-server-threaded/http_server_threaded.cpp
+++ b/example/http-server-threaded/http_server_threaded.cpp
@@ -141,11 +141,18 @@ private:
         auto res = get(full_path, file_ec);
 
         if(file_ec == beast::errc::no_such_file_or_directory)
+        {
             http::write(sock_, not_found(), ec);
+        }
         else if(ec)
+        {
             http::write(sock_, server_error(file_ec), ec);
+        }
         else
-            http::write(sock_, std::move(res), ec);
+        {
+            http::serializer<false, decltype(res)::body_type> sr{res};
+            http::write(sock_, sr, ec);
+        }
     }
 
     void

--- a/example/server-framework/http_sync_port.hpp
+++ b/example/server-framework/http_sync_port.hpp
@@ -157,7 +157,8 @@ private:
         operator()(
             beast::http::response<Body, Fields>&& res) const
         {
-            beast::http::write(self_.impl().stream(), res, ec_);
+            beast::http::serializer<false, Body, Fields> sr{res};
+            beast::http::write(self_.impl().stream(), sr, ec_);
         }
     };
 

--- a/extras/beast/unit_test/dstream.hpp
+++ b/extras/beast/unit_test/dstream.hpp
@@ -8,28 +8,22 @@
 #ifndef BEAST_UNIT_TEST_DSTREAM_HPP
 #define BEAST_UNIT_TEST_DSTREAM_HPP
 
+#include <boost/config.hpp>
 #include <ios>
 #include <memory>
 #include <ostream>
 #include <streambuf>
 #include <string>
 
-#ifdef _MSC_VER
-# ifndef NOMINMAX
-#  define NOMINMAX 1
-# endif
-# ifndef WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-# endif
-# include <windows.h>
-# undef WIN32_LEAN_AND_MEAN
-# undef NOMINMAX
+#ifdef BOOST_WINDOWS
+#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/detail/winapi/debugapi.hpp>
 #endif
 
 namespace beast {
 namespace unit_test {
 
-#ifdef _MSC_VER
+#ifdef BOOST_WINDOWS
 
 namespace detail {
 
@@ -48,14 +42,14 @@ class dstream_buf
     void write(char const* s)
     {
         if(dbg_)
-            OutputDebugStringA(s);
+            boost::detail::winapi::OutputDebugStringA(s);
         os_ << s;
     }
 
     void write(wchar_t const* s)
     {
         if(dbg_)
-            OutputDebugStringW(s);
+            boost::detail::winapi::OutputDebugStringW(s);
         os_ << s;
     }
 
@@ -63,7 +57,7 @@ public:
     explicit
     dstream_buf(ostream& os)
         : os_(os)
-        , dbg_(IsDebuggerPresent() != FALSE)
+        , dbg_(boost::detail::winapi::IsDebuggerPresent() != 0)
     {
     }
 

--- a/extras/beast/unit_test/main.cpp
+++ b/extras/beast/unit_test/main.cpp
@@ -11,12 +11,13 @@
 #include <beast/unit_test/match.hpp>
 #include <beast/unit_test/reporter.hpp>
 #include <beast/unit_test/suite.hpp>
+#include <boost/config.hpp>
 #include <boost/program_options.hpp>
 #include <cstdlib>
 #include <iostream>
 #include <vector>
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 # ifndef WIN32_LEAN_AND_MEAN // VC_EXTRALEAN
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
@@ -78,7 +79,7 @@ int main(int ac, char const* av[])
     using namespace std;
     using namespace beast::unit_test;
 
-#ifdef _MSC_VER
+#if BOOST_MSVC
     {
         int flags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
         flags |= _CRTDBG_LEAK_CHECK_DF;

--- a/include/beast/config.hpp
+++ b/include/beast/config.hpp
@@ -8,20 +8,23 @@
 #ifndef BEAST_CONFIG_HPP
 #define BEAST_CONFIG_HPP
 
+#include <boost/config.hpp>
+
+// Available to every header
 #include <boost/core/ignore_unused.hpp>
 #include <boost/static_assert.hpp>
 
 /*
 	_MSC_VER and _MSC_FULL_VER by version:
 
-	14.0 (2015)	        1900	190023026
-	14.0 (2015 Update 1)	1900	190023506
-	14.0 (2015 Update 2)	1900	190023918
-	14.0 (2015 Update 3)	1900	190024210
+	14.0 (2015)             1900    	190023026
+	14.0 (2015 Update 1)    1900    	190023506
+	14.0 (2015 Update 2)    1900    	190023918
+	14.0 (2015 Update 3)    1900    	190024210
 */
 
-#if defined(_MSC_FULL_VER)
-#if _MSC_FULL_VER < 190024210
+#ifdef BOOST_MSVC
+#if BOOST_MSVC_FULL_VER < 190024210
 static_assert(false,
 	"This library requires Visual Studio 2015 Update 3 or later");
 #endif

--- a/include/beast/core/detail/cpu_info.hpp
+++ b/include/beast/core/detail/cpu_info.hpp
@@ -20,7 +20,7 @@
 
 #if ! BEAST_NO_INTRINSICS
 
-#if defined(BOOST_MSVC)
+#ifdef BOOST_MSVC
 #include <intrin.h> // __cpuid
 #else
 #include <cpuid.h>  // __get_cpuid
@@ -41,7 +41,7 @@ cpuid(
     std::uint32_t& ecx,
     std::uint32_t& edx)
 {
-#if defined(BOOST_MSVC)
+#ifdef BOOST_MSVC
     int regs[4];
     __cpuid(regs, id);
     eax = regs[0];

--- a/include/beast/core/detail/integer_sequence.hpp
+++ b/include/beast/core/detail/integer_sequence.hpp
@@ -8,6 +8,7 @@
 #ifndef BEAST_DETAIL_INTEGER_SEQUENCE_HPP
 #define BEAST_DETAIL_INTEGER_SEQUENCE_HPP
 
+#include <boost/config.hpp>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -39,9 +40,9 @@ struct sizeof_workaround
     static std::size_t constexpr size = sizeof... (Args);
 };
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 
-// This implementation compiles on MSVC and clang but not gcc
+// This implementation compiles on real MSVC and clang but not gcc
 
 template<class T, unsigned long long N, class Seq>
 struct make_integer_sequence_unchecked;

--- a/include/beast/core/file_win32.hpp
+++ b/include/beast/core/file_win32.hpp
@@ -75,7 +75,7 @@ public:
 
     /// Returns the native handle associated with the file.
     native_handle_type
-    native_handle() const
+    native_handle()
     {
         return h_;
     }
@@ -130,7 +130,7 @@ public:
         @return The offset in bytes from the beginning of the file
     */
     std::uint64_t
-    pos(error_code& ec) const;
+    pos(error_code& ec);
 
     /** Adjust the current position in the open file
 
@@ -150,7 +150,7 @@ public:
         @param ec Set to the error, if any occurred
     */
     std::size_t
-    read(void* buffer, std::size_t n, error_code& ec) const;
+    read(void* buffer, std::size_t n, error_code& ec);
 
     /** Write to the open file
 

--- a/include/beast/core/impl/file_win32.ipp
+++ b/include/beast/core/impl/file_win32.ipp
@@ -226,7 +226,7 @@ size(error_code& ec) const
 inline
 std::uint64_t
 file_win32::
-pos(error_code& ec) const
+pos(error_code& ec)
 {
     if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
     {
@@ -272,7 +272,7 @@ seek(std::uint64_t offset, error_code& ec)
 inline
 std::size_t
 file_win32::
-read(void* buffer, std::size_t n, error_code& ec) const
+read(void* buffer, std::size_t n, error_code& ec)
 {
     if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
     {

--- a/include/beast/http/buffer_body.hpp
+++ b/include/beast/http/buffer_body.hpp
@@ -101,9 +101,14 @@ struct buffer_body
 
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, buffer_body,
-                Fields> const& msg, error_code& ec)
+        reader(message<isRequest,
+                buffer_body, Fields> const& msg)
             : body_(msg.body)
+        {
+        }
+
+        void
+        init(error_code& ec)
         {
             ec.assign(0, ec.category());
         }
@@ -152,10 +157,13 @@ struct buffer_body
     public:
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest, buffer_body, Fields>& m,
-                boost::optional<std::uint64_t> const&,
-                    error_code& ec)
+        writer(message<isRequest, buffer_body, Fields>& m)
             : body_(m.body)
+        {
+        }
+
+        void
+        init(boost::optional<std::uint64_t> const&, error_code& ec)
         {
             ec.assign(0, ec.category());
         }

--- a/include/beast/http/detail/basic_parser.hpp
+++ b/include/beast/http/detail/basic_parser.hpp
@@ -797,6 +797,11 @@ protected:
                 p = parse_token_to_eol(p, last, token_last, ec);
                 if(ec)
                     return;
+                if(! p)
+                {
+                    ec = error::bad_value;
+                    return;
+                }
                 // Look 1 char past the CRLF to handle obs-fold.
                 if(p + 1 > last)
                 {

--- a/include/beast/http/dynamic_body.hpp
+++ b/include/beast/http/dynamic_body.hpp
@@ -55,9 +55,14 @@ struct basic_dynamic_body
 
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, basic_dynamic_body,
-                Fields> const& m, error_code& ec)
+        reader(message<isRequest,
+                basic_dynamic_body, Fields> const& m)
             : body_(m.body)
+        {
+        }
+
+        void
+        init(error_code& ec)
         {
             ec.assign(0, ec.category());
         }
@@ -82,10 +87,13 @@ struct basic_dynamic_body
     public:
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest, basic_dynamic_body, Fields>& msg,
-            boost::optional<std::uint64_t> const&,
-                error_code& ec)
+        writer(message<isRequest, basic_dynamic_body, Fields>& msg)
             : body_(msg.body)
+        {
+        }
+
+        void
+        init(boost::optional<std::uint64_t> const&, error_code& ec)
         {
             ec.assign(0, ec.category());
         }

--- a/include/beast/http/empty_body.hpp
+++ b/include/beast/http/empty_body.hpp
@@ -54,8 +54,13 @@ struct empty_body
 
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, empty_body,
-            Fields> const&, error_code& ec)
+        reader(message<isRequest,
+            empty_body, Fields> const&)
+        {
+        }
+
+        void
+        init(error_code& ec)
         {
             ec.assign(0, ec.category());
         }
@@ -77,9 +82,12 @@ struct empty_body
     {
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest, empty_body, Fields>&,
-            boost::optional<std::uint64_t> const&,
-                error_code& ec)
+        writer(message<isRequest, empty_body, Fields>&)
+        {
+        }
+
+        void
+        init(boost::optional<std::uint64_t> const&, error_code& ec)
         {
             ec.assign(0, ec.category());
         }

--- a/include/beast/http/file_body.hpp
+++ b/include/beast/http/file_body.hpp
@@ -516,4 +516,6 @@ using file_body = basic_file_body<file>;
 } // http
 } // beast
 
+#include <beast/http/impl/file_body_win32.ipp>
+
 #endif

--- a/include/beast/http/impl/file_body_win32.ipp
+++ b/include/beast/http/impl/file_body_win32.ipp
@@ -1,0 +1,579 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BEAST_HTTP_IMPL_FILE_BODY_WIN32_IPP
+#define BEAST_HTTP_IMPL_FILE_BODY_WIN32_IPP
+
+#if BEAST_USE_WIN32_FILE
+
+#include <beast/core/async_result.hpp>
+#include <beast/core/bind_handler.hpp>
+#include <beast/core/type_traits.hpp>
+#include <beast/core/detail/clamp.hpp>
+#include <beast/http/serializer.hpp>
+#include <boost/asio/basic_stream_socket.hpp>
+#include <boost/asio/handler_alloc_hook.hpp>
+#include <boost/asio/handler_continuation_hook.hpp>
+#include <boost/asio/handler_invoke_hook.hpp>
+#include <boost/asio/windows/overlapped_ptr.hpp>
+#include <boost/make_unique.hpp>
+#include <boost/smart_ptr/make_shared_array.hpp>
+#include <boost/detail/winapi/basic_types.hpp>
+#include <algorithm>
+#include <cstring>
+
+namespace beast {
+namespace http {
+
+namespace detail {
+template<class, class, bool, class, class>
+class write_some_win32_op;
+} // detail
+
+template<>
+struct basic_file_body<file_win32>
+{
+    using file_type = file_win32;
+
+    class reader;
+    class writer;
+
+    //--------------------------------------------------------------------------
+
+    class value_type
+    {
+        friend class reader;
+        friend class writer;
+        friend struct basic_file_body<file_win32>;
+
+        template<class, class, bool, class, class>
+        friend class detail::write_some_win32_op;
+        template<class Protocol, bool isRequest,
+            class Fields, class Decorator>
+        friend
+        void
+        write_some(
+            boost::asio::basic_stream_socket<Protocol>& sock,
+            serializer<isRequest, basic_file_body<file_win32>,
+                Fields, Decorator>& sr,
+            error_code& ec);
+
+        file_win32 file_;
+        std::uint64_t size_ = 0;    // cached file size
+        std::uint64_t first_;       // starting offset of the range
+        std::uint64_t last_;        // ending offset of the range
+
+    public:
+        ~value_type() = default;
+        value_type() = default;
+        value_type(value_type&& other) = default;
+        value_type& operator=(value_type&& other) = default;
+
+        bool
+        is_open() const
+        {
+            return file_.is_open();
+        }
+
+        std::uint64_t
+        size() const
+        {
+            return size_;
+        }
+
+        void
+        close();
+
+        void
+        open(char const* path, file_mode mode, error_code& ec);
+
+        void
+        reset(file_win32&& file, error_code& ec);
+    };
+
+    //--------------------------------------------------------------------------
+
+    class reader
+    {
+        template<class, class, bool, class, class>
+        friend class detail::write_some_win32_op;
+        template<class Protocol, bool isRequest,
+            class Fields, class Decorator>
+        friend
+        void
+        write_some(
+            boost::asio::basic_stream_socket<Protocol>& sock,
+            serializer<isRequest, basic_file_body<file_win32>,
+                Fields, Decorator>& sr,
+            error_code& ec);
+
+        value_type& body_;  // The body we are reading from
+        std::uint64_t pos_; // The current position in the file
+        char buf_[4096];    // Small buffer for reading
+
+    public:
+        using const_buffers_type =
+            boost::asio::const_buffers_1;
+
+        template<bool isRequest, class Fields>
+        reader(message<isRequest,
+                basic_file_body<file_win32>, Fields>& m)
+            : body_(m.body)
+        {
+        }
+
+        void
+        init(error_code&)
+        {
+            BOOST_ASSERT(body_.file_.is_open());
+            pos_ = body_.first_;
+        }
+
+        boost::optional<std::pair<const_buffers_type, bool>>
+        get(error_code& ec)
+        {
+            std::size_t const n = (std::min)(sizeof(buf_),
+                beast::detail::clamp(body_.last_ - pos_));
+            if(n == 0)
+            {
+                ec.assign(0, ec.category());
+                return boost::none;
+            }
+            auto const nread = body_.file_.read(buf_, n, ec);
+            if(ec)
+                return boost::none;
+            BOOST_ASSERT(nread != 0);
+            pos_ += nread;
+            ec.assign(0, ec.category());
+            return {{
+                {buf_, nread},          // buffer to return.
+                pos_ < body_.last_}};   // `true` if there are more buffers.
+        }
+    };
+
+    //--------------------------------------------------------------------------
+
+    class writer
+    {
+        value_type& body_;
+
+    public:
+        template<bool isRequest, class Fields>
+        explicit
+        writer(message<isRequest, basic_file_body, Fields>& m)
+            : body_(m.body)
+        {
+        }
+
+        void
+        init(boost::optional<
+            std::uint64_t> const& content_length,
+                error_code& ec)
+        {
+            // VFALCO We could reserve space in the file
+            boost::ignore_unused(content_length);
+            BOOST_ASSERT(body_.file_.is_open());
+            ec.assign(0, ec.category());
+        }
+
+        template<class ConstBufferSequence>
+        std::size_t
+        put(ConstBufferSequence const& buffers,
+            error_code& ec)
+        {
+            std::size_t nwritten = 0;
+            for(boost::asio::const_buffer buffer : buffers)
+            {
+                nwritten += body_.file_.write(
+                    boost::asio::buffer_cast<void const*>(buffer),
+                    boost::asio::buffer_size(buffer),
+                    ec);
+                if(ec)
+                    return nwritten;
+            }
+            ec.assign(0, ec.category());
+            return nwritten;
+        }
+
+        void
+        finish(error_code& ec)
+        {
+            ec.assign(0, ec.category());
+        }
+    };
+
+    //--------------------------------------------------------------------------
+
+    static
+    std::uint64_t
+    size(value_type const& body)
+    {
+        return body.size();
+    }
+};
+
+//------------------------------------------------------------------------------
+
+inline
+void
+basic_file_body<file_win32>::
+value_type::
+close()
+{
+    error_code ignored;
+    file_.close(ignored);
+}
+
+inline
+void
+basic_file_body<file_win32>::
+value_type::
+open(char const* path, file_mode mode, error_code& ec)
+{
+    file_.open(path, mode, ec);
+    if(ec)
+        return;
+    size_ = file_.size(ec);
+    if(ec)
+    {
+        close();
+        return;
+    }
+    first_ = 0;
+    last_ = size_;
+}
+
+inline
+void
+basic_file_body<file_win32>::
+value_type::
+reset(file_win32&& file, error_code& ec)
+{
+    if(file_.is_open())
+    {
+        error_code ignored;
+        file_.close(ignored);
+    }
+    file_ = std::move(file);
+    if(file_.is_open())
+    {
+        size_ = file_.size(ec);
+        if(ec)
+        {
+            close();
+            return;
+        }
+        first_ = 0;
+        last_ = size_;
+    }
+}
+
+//------------------------------------------------------------------------------
+
+namespace detail {
+
+template<class Unsigned>
+inline
+boost::detail::winapi::DWORD_
+lowPart(Unsigned n)
+{
+    return static_cast<
+        boost::detail::winapi::DWORD_>(
+            n & 0xffffffff);
+}
+
+template<class Unsigned>
+inline
+boost::detail::winapi::DWORD_
+highPart(Unsigned n, std::true_type)
+{
+    return static_cast<
+        boost::detail::winapi::DWORD_>(
+            (n>>32)&0xffffffff);
+}
+
+template<class Unsigned>
+inline
+boost::detail::winapi::DWORD_
+highPart(Unsigned, std::false_type)
+{
+    return 0;
+}
+
+template<class Unsigned>
+inline
+boost::detail::winapi::DWORD_
+highPart(Unsigned n)
+{
+    return highPart(n, std::integral_constant<
+        bool, (sizeof(Unsigned)>4)>{});
+}
+
+class null_lambda
+{
+public:
+    template<class ConstBufferSequence>
+    void
+    operator()(error_code&,
+        ConstBufferSequence const&) const
+    {
+        BOOST_ASSERT(false);
+    }
+};
+
+//------------------------------------------------------------------------------
+
+#if BOOST_ASIO_HAS_WINDOWS_OVERLAPPED_PTR
+
+template<class Protocol, class Handler,
+    bool isRequest, class Fields, class Decorator>
+class write_some_win32_op
+{
+    boost::asio::basic_stream_socket<Protocol>& sock_;
+    serializer<isRequest, basic_file_body<file_win32>,
+        Fields, Decorator>& sr_;
+    bool header_ = false;
+    Handler h_;
+
+public:
+    write_some_win32_op(write_some_win32_op&&) = default;
+    write_some_win32_op(write_some_win32_op const&) = default;
+
+    template<class DeducedHandler>
+    write_some_win32_op(
+        DeducedHandler&& h,
+        boost::asio::basic_stream_socket<Protocol>& s,
+        serializer<isRequest, basic_file_body<file_win32>,
+            Fields, Decorator>& sr)
+        : sock_(s)
+        , sr_(sr)
+        , h_(std::forward<DeducedHandler>(h))
+    {
+    }
+
+    void
+    operator()();
+
+    void
+    operator()(error_code ec,
+        std::size_t bytes_transferred = 0);
+
+    friend
+    void* asio_handler_allocate(
+        std::size_t size, write_some_win32_op* op)
+    {
+        using boost::asio::asio_handler_allocate;
+        return asio_handler_allocate(
+            size, std::addressof(op->h_));
+    }
+
+    friend
+    void asio_handler_deallocate(
+        void* p, std::size_t size, write_some_win32_op* op)
+    {
+        using boost::asio::asio_handler_deallocate;
+        asio_handler_deallocate(
+            p, size, std::addressof(op->h_));
+    }
+
+    friend
+    bool asio_handler_is_continuation(write_some_win32_op* op)
+    {
+        using boost::asio::asio_handler_is_continuation;
+        return asio_handler_is_continuation(
+            std::addressof(op->h_));
+    }
+
+    template<class Function>
+    friend
+    void asio_handler_invoke(Function&& f, write_some_win32_op* op)
+    {
+        using boost::asio::asio_handler_invoke;
+        asio_handler_invoke(
+            f, std::addressof(op->h_));
+    }
+};
+
+template<class Protocol, class Handler,
+    bool isRequest, class Fields, class Decorator>
+void
+write_some_win32_op<
+    Protocol, Handler, isRequest, Fields, Decorator>::
+operator()()
+{
+    if(! sr_.is_header_done())
+    {
+        header_ = true;
+        sr_.split(true);
+        return detail::async_write_some(
+            sock_, sr_, std::move(*this));
+    }
+    if(sr_.chunked())
+    {
+        return detail::async_write_some(
+            sock_, sr_, std::move(*this));
+    }
+    auto& r = sr_.reader_impl();
+    boost::detail::winapi::DWORD_ const nNumberOfBytesToWrite =
+        std::min<boost::detail::winapi::DWORD_>(
+            beast::detail::clamp(std::min<std::uint64_t>(
+                r.body_.last_ - r.pos_, sr_.limit())),
+            2147483646);
+    boost::asio::windows::overlapped_ptr overlapped{
+        sock_.get_io_service(), *this};
+    auto& ov = *overlapped.get();
+    ov.Offset = lowPart(r.pos_);
+    ov.OffsetHigh = highPart(r.pos_);
+    auto const bSuccess = ::TransmitFile(
+        sock_.native_handle(),
+        sr_.get().body.file_.native_handle(),
+        nNumberOfBytesToWrite,
+        0,
+        overlapped.get(),
+        nullptr,
+        0);
+    auto const dwError = ::GetLastError();
+    if(! bSuccess && dwError !=
+        boost::detail::winapi::ERROR_IO_PENDING_)
+    {
+        // completed immediately
+        overlapped.complete(error_code{static_cast<int>(
+            boost::detail::winapi::GetLastError()),
+                system_category()}, 0);
+        return;
+    }
+    overlapped.release();
+}
+
+template<class Protocol, class Handler,
+    bool isRequest, class Fields, class Decorator>
+void
+write_some_win32_op<
+    Protocol, Handler,isRequest, Fields, Decorator>::
+operator()(error_code ec, std::size_t bytes_transferred)
+{
+    if(! ec)
+    {
+        if(header_)
+        {
+            header_ = false;
+            return (*this)();
+        }
+        auto& r = sr_.reader_impl();
+        r.pos_ += bytes_transferred;
+        BOOST_ASSERT(r.pos_ <= r.body_.last_);
+        if(r.pos_ >= r.body_.last_)
+        {
+            sr_.next(ec, null_lambda{});
+            BOOST_ASSERT(! ec);
+            BOOST_ASSERT(sr_.is_done());
+            if(! sr_.keep_alive())
+                ec = error::end_of_stream;
+        }
+    }
+    h_(ec);
+}
+
+#endif
+
+} // detail
+
+//------------------------------------------------------------------------------
+
+template<class Protocol,
+    bool isRequest, class Fields, class Decorator>
+void
+write_some(
+    boost::asio::basic_stream_socket<Protocol>& sock,
+    serializer<isRequest, basic_file_body<file_win32>,
+        Fields, Decorator>& sr,
+    error_code& ec)
+{
+    if(! sr.is_header_done())
+    {
+        sr.split(true);
+        detail::write_some(sock, sr, ec);
+        if(ec)
+            return;
+        return;
+    }
+    if(sr.chunked())
+    {
+        detail::write_some(sock, sr, ec);
+        if(ec)
+            return;
+        return;
+    }
+    auto& r = sr.reader_impl();
+    r.body_.file_.seek(r.pos_, ec);
+    if(ec)
+        return;
+    boost::detail::winapi::DWORD_ const nNumberOfBytesToWrite =
+        std::min<boost::detail::winapi::DWORD_>(
+            beast::detail::clamp(std::min<std::uint64_t>(
+                r.body_.last_ - r.pos_, sr.limit())),
+            2147483646);
+    auto const bSuccess = ::TransmitFile(
+        sock.native_handle(),
+        r.body_.file_.native_handle(),
+        nNumberOfBytesToWrite,
+        0,
+        nullptr,
+        nullptr,
+        0);
+    if(! bSuccess)
+    {
+        ec.assign(static_cast<int>(
+            boost::detail::winapi::GetLastError()),
+                system_category());
+        return;
+    }
+    r.pos_ += nNumberOfBytesToWrite;
+    BOOST_ASSERT(r.pos_ <= r.body_.last_);
+    if(r.pos_ < r.body_.last_)
+    {
+        ec.assign(0, ec.category());
+    }
+    else
+    {
+        sr.next(ec, detail::null_lambda{});
+        BOOST_ASSERT(! ec);
+        BOOST_ASSERT(sr.is_done());
+        if(! sr.keep_alive())
+            ec = error::end_of_stream;
+    }
+}
+
+#if BOOST_ASIO_HAS_WINDOWS_OVERLAPPED_PTR
+
+template<
+    class Protocol,
+    bool isRequest, class Fields, class Decorator,
+    class WriteHandler>
+async_return_type<WriteHandler, void(error_code)>
+async_write_some(
+    boost::asio::basic_stream_socket<Protocol>& sock,
+    serializer<isRequest, basic_file_body<file_win32>,
+        Fields, Decorator>& sr,
+    WriteHandler&& handler)
+{
+    async_completion<WriteHandler,
+        void(error_code)> init{handler};
+    detail::write_some_win32_op<Protocol, handler_type<
+        WriteHandler, void(error_code)>, isRequest, Fields,
+            Decorator>{init.completion_handler, sock, sr}();
+    return init.result.get();
+}
+
+#endif
+
+} // http
+} // beast
+
+#endif
+
+#endif

--- a/include/beast/http/impl/parser.ipp
+++ b/include/beast/http/impl/parser.ipp
@@ -15,11 +15,19 @@ namespace beast {
 namespace http {
 
 template<bool isRequest, class Body, class Allocator>
+parser<isRequest, Body, Allocator>::
+parser()
+    : wr_(m_)
+{
+}
+
+template<bool isRequest, class Body, class Allocator>
 template<class Arg1, class... ArgN, class>
 parser<isRequest, Body, Allocator>::
 parser(Arg1&& arg1, ArgN&&... argn)
     : m_(std::forward<Arg1>(arg1),
         std::forward<ArgN>(argn)...)
+    , wr_(m_)
 {
 }
 
@@ -30,8 +38,9 @@ parser(parser<isRequest, OtherBody, Allocator>&& p,
         Args&&... args)
     : base_type(std::move(p))
     , m_(p.release(), std::forward<Args>(args)...)
+    , wr_(m_)
 {
-    if(p.wr_)
+    if(wr_inited_)
         BOOST_THROW_EXCEPTION(std::invalid_argument{
             "moved-from parser has a body"});
 }

--- a/include/beast/http/impl/serializer.ipp
+++ b/include/beast/http/impl/serializer.ipp
@@ -87,7 +87,8 @@ next(error_code& ec, Visit&& visit)
         frdinit(std::integral_constant<bool,
             isRequest>{});
         close_ = ! frd_->keep_alive();
-        if(frd_->chunked())
+        chunked_ = frd_->chunked();
+        if(chunked_)
             goto go_init_c;
         s_ = do_init;
         BEAST_FALLTHROUGH;

--- a/include/beast/http/impl/serializer.ipp
+++ b/include/beast/http/impl/serializer.ipp
@@ -52,11 +52,20 @@ do_visit(error_code& ec, Visit& visit)
         boost::get<T1>(pv_)));
 }
 
+//------------------------------------------------------------------------------
+
 template<bool isRequest, class Body,
     class Fields, class ChunkDecorator>
 serializer<isRequest, Body, Fields, ChunkDecorator>::
-serializer(message<isRequest, Body, Fields> const& m,
-        ChunkDecorator const& d)
+serializer(value_type& m)
+    : m_(m)
+{
+}
+
+template<bool isRequest, class Body,
+    class Fields, class ChunkDecorator>
+serializer<isRequest, Body, Fields, ChunkDecorator>::
+serializer(value_type& m, ChunkDecorator const& d)
     : m_(m)
     , d_(d)
 {

--- a/include/beast/http/impl/serializer.ipp
+++ b/include/beast/http/impl/serializer.ipp
@@ -86,7 +86,7 @@ next(error_code& ec, Visit&& visit)
     {
         frdinit(std::integral_constant<bool,
             isRequest>{});
-        close_ = ! frd_->keep_alive();
+        keep_alive_ = frd_->keep_alive();
         chunked_ = frd_->chunked();
         if(chunked_)
             goto go_init_c;

--- a/include/beast/http/impl/write.ipp
+++ b/include/beast/http/impl/write.ipp
@@ -163,7 +163,7 @@ operator()(
     {
         sr_.consume(bytes_transferred);
         if(sr_.is_done())
-            if(sr_.need_close())
+            if(! sr_.keep_alive())
                 ec = error::end_of_stream;
     }
     h_(ec);
@@ -480,11 +480,11 @@ write_some(
         if(f.invoked)
             sr.consume(f.bytes_transferred);
         if(sr.is_done())
-            if(sr.need_close())
+            if(! sr.keep_alive())
                 ec = error::end_of_stream;
         return;
     }
-    if(sr.need_close())
+    if(! sr.keep_alive())
         ec = error::end_of_stream;
     else
         ec.assign(0, ec.category());

--- a/include/beast/http/impl/write.ipp
+++ b/include/beast/http/impl/write.ipp
@@ -177,7 +177,7 @@ struct serializer_is_header_done
         class Fields, class Decorator>
     bool
     operator()(serializer<isRequest, Body,
-        Fields, Decorator> const& sr) const
+        Fields, Decorator>& sr) const
     {
         return sr.is_header_done();
     }
@@ -189,7 +189,7 @@ struct serializer_is_done
         class Fields, class Decorator>
     bool
     operator()(serializer<isRequest, Body,
-        Fields, Decorator> const& sr) const
+        Fields, Decorator>& sr) const
     {
         return sr.is_done();
     }

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -318,7 +318,7 @@ public:
 
     /// Returns the serialized buffer size limit
     std::size_t
-    limit() const
+    limit()
     {
         return limit_;
     }
@@ -344,7 +344,7 @@ public:
     /** Returns `true` if we will pause after writing the complete header.
     */
     bool
-    split() const
+    split()
     {
         return split_;
     }
@@ -368,7 +368,7 @@ public:
         serialized header octets have been retrieved.
     */
     bool
-    is_header_done() const
+    is_header_done()
     {
         return header_done_;
     }
@@ -380,7 +380,7 @@ public:
         successfully retrieved.
     */
     bool
-    is_done() const
+    is_done()
     {
         return s_ == do_complete;
     }

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -385,6 +385,17 @@ public:
         return s_ == do_complete;
     }
 
+    /** Return `true` if the serializer will apply chunk-encoding.
+
+        This function may only be called if @ref is_header_done
+        would return `true`.
+    */
+    bool
+    chunked()
+    {
+        return chunked_;
+    }
+
     /** Return `true` if Connection: close semantic is indicated.
 
         Depending on the contents of the message, the end of
@@ -392,6 +403,9 @@ public:
         for the recipient (if any) to receive a complete message,
         the underlying network connection must be closed when this
         function returns `true`.
+
+        This function may only be called if @ref is_header_done
+        would return `true`.
     */
     bool
     need_close() const

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -134,7 +134,7 @@ public:
     static_assert(is_body_reader<Body>::value,
         "BodyReader requirements not met");
 
-    /** The type of the message referenced by this object.
+    /** The type of message this serializer uses
 
         This may be const or non-const depending on the
         implementation of the corresponding @b BodyReader.
@@ -145,11 +145,9 @@ public:
     using value_type =
         typename std::conditional<
             std::is_constructible<typename Body::reader,
-                message<isRequest, Body, Fields>&,
-                    error_code&>::value &&
+                message<isRequest, Body, Fields>&>::value &&
             ! std::is_constructible<typename Body::reader,
-                message<isRequest, Body, Fields> const&,
-                    error_code&>::value,
+                message<isRequest, Body, Fields> const&>::value,
             message<isRequest, Body, Fields>,
             message<isRequest, Body, Fields> const>::type;
 #endif
@@ -248,8 +246,8 @@ private:
     using pcb8_t = buffer_prefix_view<cb8_t const&>;
 
     value_type& m_;
+    reader rd_;
     boost::optional<typename Fields::reader> frd_;
-    boost::optional<reader> rd_;
     boost::variant<boost::blank,
         cb1_t, cb2_t, cb3_t, cb4_t, cb5_t
     #ifndef BEAST_NO_BIG_VARIANTS

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -309,6 +309,13 @@ public:
     explicit
     serializer(value_type& msg, ChunkDecorator const& decorator);
 
+    /// Returns the message being serialized
+    value_type&
+    get()
+    {
+        return m_;
+    }
+
     /// Returns the serialized buffer size limit
     std::size_t
     limit() const

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -67,7 +67,7 @@ struct no_chunk_decorator
     if the contents of the message indicate that chunk encoding
     is required. If the semantics of the message indicate that
     the connection should be closed after the message is sent, the
-    function @ref need_close will return `true`.
+    function @ref keep_alive will return `true`.
 
     Upon construction, an optional chunk decorator may be
     specified. This decorator is a function object called with
@@ -268,7 +268,7 @@ private:
     bool split_ = false;
     bool header_done_ = false;
     bool chunked_;
-    bool close_;
+    bool keep_alive_;
     bool more_;
     ChunkDecorator d_;
 
@@ -396,21 +396,28 @@ public:
         return chunked_;
     }
 
-    /** Return `true` if Connection: close semantic is indicated.
+    /** Return `true` if Connection: keep-alive semantic is indicated.
 
-        Depending on the contents of the message, the end of
-        the body may be indicated by the end of file. In order
-        for the recipient (if any) to receive a complete message,
-        the underlying network connection must be closed when this
-        function returns `true`.
+        This function returns `true` if the semantics of the
+        message indicate that the connection should be kept open
+        after the serialized message has been transmitted. The
+        value depends on the HTTP version of the message,
+        the tokens in the Connection header, and the metadata
+        describing the payload body.
+
+        Depending on the payload body, the end of the message may
+        be indicated by connection closuire. In order for the
+        recipient (if any) to receive a complete message, the
+        underlying stream or network connection must be closed
+        when this function returns `false`.
 
         This function may only be called if @ref is_header_done
         would return `true`.
     */
     bool
-    need_close() const
+    keep_alive()
     {
-        return close_;
+        return keep_alive_;
     }
 
     /** Returns the next set of buffers in the serialization.

--- a/include/beast/http/serializer.hpp
+++ b/include/beast/http/serializer.hpp
@@ -314,6 +314,22 @@ public:
         return m_;
     }
 
+    /** Provides access to the associated @b BodyReader
+
+        This function provides access to the instance of the reader
+        associated with the body and created by the serializer
+        upon construction. The behavior of accessing this object
+        is defined by the specification of the particular reader
+        and its associated body.
+
+        @return A reference to the reader.
+    */
+    reader&
+    reader_impl()
+    {
+        return rd_;
+    }
+
     /// Returns the serialized buffer size limit
     std::size_t
     limit()
@@ -335,7 +351,7 @@ public:
     void
     limit(std::size_t limit)
     {
-        limit_ = limit > 0 ? limit:
+        limit_ = limit > 0 ? limit :
             (std::numeric_limits<std::size_t>::max)();
     }
 

--- a/include/beast/http/string_body.hpp
+++ b/include/beast/http/string_body.hpp
@@ -52,9 +52,14 @@ struct string_body
 
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, string_body,
-                Fields> const& msg, error_code& ec)
+        reader(message<isRequest,
+                string_body, Fields> const& msg)
             : body_(msg.body)
+        {
+        }
+
+        void
+        init(error_code& ec)
         {
             ec.assign(0, ec.category());
         }
@@ -80,23 +85,27 @@ struct string_body
     public:
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest, string_body, Fields>& m,
-            boost::optional<std::uint64_t> content_length,
-                error_code& ec)
+        writer(message<isRequest, string_body, Fields>& m)
             : body_(m.body)
         {
-            if(content_length)
+        }
+
+        void
+        init(boost::optional<
+            std::uint64_t> const& length, error_code& ec)
+        {
+            if(length)
             {
-                if(*content_length > (std::numeric_limits<
-                        std::size_t>::max)())
+                if(*length > (
+                    std::numeric_limits<std::size_t>::max)())
                 {
                     ec = error::buffer_overflow;
                     return;
                 }
                 try
                 {
-                    body_.reserve(static_cast<
-                        std::size_t>(*content_length));
+                    body_.reserve(
+                        static_cast<std::size_t>(*length));
                 }
                 catch(std::exception const&)
                 {

--- a/include/beast/http/string_view_body.hpp
+++ b/include/beast/http/string_view_body.hpp
@@ -53,9 +53,14 @@ struct string_view_body
 
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, string_view_body,
-                Fields> const& m, error_code& ec)
+        reader(message<isRequest,
+                string_view_body, Fields> const& m)
             : body_(m.body)
+        {
+        }
+
+        void
+        init(error_code& ec)
         {
             ec.assign(0, ec.category());
         }

--- a/include/beast/http/type_traits.hpp
+++ b/include/beast/http/type_traits.hpp
@@ -87,10 +87,10 @@ struct is_body_reader<T, beast::detail::void_t<
     is_const_buffer_sequence<
         typename T::reader::const_buffers_type>::value &&
     std::is_constructible<typename T::reader,
-        message<true, T, detail::fields_model> const&,
+        message<true, T, detail::fields_model>&,
         error_code&>::value &&
     std::is_constructible<typename T::reader,
-        message<false, T, detail::fields_model> const&,
+        message<false, T, detail::fields_model>&,
         error_code&>::value
     > {};
 #endif

--- a/include/beast/http/type_traits.hpp
+++ b/include/beast/http/type_traits.hpp
@@ -80,6 +80,7 @@ struct is_body_reader<T, beast::detail::void_t<
     typename T::reader,
     typename T::reader::const_buffers_type,
         decltype(
+    std::declval<typename T::reader&>().init(std::declval<error_code&>()),
     std::declval<boost::optional<std::pair<
             typename T::reader::const_buffers_type, bool>>&>() =
             std::declval<typename T::reader>().get(std::declval<error_code&>()),
@@ -87,11 +88,9 @@ struct is_body_reader<T, beast::detail::void_t<
     is_const_buffer_sequence<
         typename T::reader::const_buffers_type>::value &&
     std::is_constructible<typename T::reader,
-        message<true, T, detail::fields_model>&,
-        error_code&>::value &&
+        message<true, T, detail::fields_model>&>::value &&
     std::is_constructible<typename T::reader,
-        message<false, T, detail::fields_model>&,
-        error_code&>::value
+        message<false, T, detail::fields_model>&>::value
     > {};
 #endif
 
@@ -124,6 +123,9 @@ struct is_body_writer : std::false_type {};
 
 template<class T>
 struct is_body_writer<T, beast::detail::void_t<decltype(
+    std::declval<typename T::writer&>().init(
+        boost::optional<std::uint64_t>(),
+        std::declval<error_code&>()),
     std::declval<std::size_t&>() =
         std::declval<typename T::writer&>().put(
             std::declval<boost::asio::const_buffers_1>(),
@@ -132,10 +134,10 @@ struct is_body_writer<T, beast::detail::void_t<decltype(
         std::declval<error_code&>()),
     (void)0)>> : std::integral_constant<bool,
         std::is_constructible<typename T::writer,
-            message<true, T, detail::fields_model>&,
-            boost::optional<std::uint64_t>,
-            error_code&
-        >::value>
+            message<true, T, detail::fields_model>&>::value &&
+        std::is_constructible<typename T::writer,
+            message<false, T, detail::fields_model>&>::value
+            >
 {
 };
 #endif

--- a/include/beast/version.hpp
+++ b/include/beast/version.hpp
@@ -18,7 +18,7 @@
     This is a simple integer that is incremented by one every time
     a set of code changes is merged to the master or develop branch.
 */
-#define BEAST_VERSION 75
+#define BEAST_VERSION 76
 
 #define BEAST_VERSION_STRING "Beast/" BOOST_STRINGIZE(BEAST_VERSION)
 

--- a/test/benchmarks/nodejs_parser.cpp
+++ b/test/benchmarks/nodejs_parser.cpp
@@ -10,7 +10,9 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 
-#ifdef _MSC_VER
+#include <boost/config.hpp>
+
+#ifdef BOOST_MSVC
 # pragma warning (push)
 # pragma warning (disable: 4127) // conditional expression is constant
 # pragma warning (disable: 4244) // integer conversion, possible loss of data
@@ -18,7 +20,7 @@
 
 #include "nodejs-parser/http_parser.c"
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 # pragma warning (pop)
 #endif
 

--- a/test/exemplars.cpp
+++ b/test/exemplars.cpp
@@ -58,10 +58,24 @@ public:
 
         @param ec Set to the error, if any occurred.
     */
-    template<bool isRequest, class Body, class Headers>
+    template<bool isRequest, class Body, class Fields>
     explicit
-    BodyReader(message<isRequest, Body, Headers> const& msg,
-        error_code &ec);
+    BodyReader(message<isRequest, Body, Fields> const& msg);
+
+    /** Initialize the reader
+
+        This is called after construction and before the first
+        call to `get`. The message is valid and complete upon
+        entry.
+
+        @param ec Set to the error, if any occurred.
+    */
+    void
+    init(error_code& ec)
+    {
+        // The specification requires this to indicate "no error"
+        ec.assign(0, ec.category());
+    }
 
     /** Returns the next buffer in the body.
 
@@ -85,7 +99,7 @@ public:
     get(error_code& ec)
     {
         // The specification requires this to indicate "no error"
-        ec = {};
+        ec.assign(0, ec.category());
 
         return boost::none; // for exposition only
     }
@@ -109,14 +123,25 @@ struct BodyWriter
     */
     template<bool isRequest, class Body, class Fields>
     explicit
-    BodyWriter(message<isRequest, Body, Fields>& msg,
-        boost::optional<std::uint64_t> content_length,
-            error_code& ec)
+    BodyWriter(message<isRequest, Body, Fields>& msg);
+
+    /** Initialize the writer
+
+        This is called after construction and before the first
+        call to `put`. The message is valid and complete upon
+        entry.
+
+        @param ec Set to the error, if any occurred.
+    */
+    void
+    init(
+        boost::optional<std::uint64_t> const& content_length,
+        error_code& ec)
     {
-        boost::ignore_unused(msg, content_length);
+        boost::ignore_unused(content_length);
 
         // The specification requires this to indicate "no error"
-        ec = {};
+        ec.assign(0, ec.category());
     }
 
     /** Store buffers.

--- a/test/http/basic_parser.cpp
+++ b/test/http/basic_parser.cpp
@@ -1104,6 +1104,40 @@ public:
     //--------------------------------------------------------------------------
 
     void
+    testFuzz1()
+    {
+        error_code ec;
+        test_parser<true> p;
+        feed(buf(
+            "LOCK /%e7lY;/;;%0b8=p/r HTTP/1.1\r\n"
+            "Accept-Encoding:\r\n"
+            "	 î\r\n"
+            "Original-Message-ID:ë				ÿÿÿÿÿÿÿÿ: \r\n"
+            "	 ÷D›¥Ÿ\r\n"
+            "Resent-Date:ô\r\n"
+            "Alt-Svc: \r\n"
+            "Trailer:  	   \r\n"
+            "List-ID:¦k†		\r\n" 	
+            "Alternate-Recipient:óã\"ïû„qJÌ¼–÷[rñò\r\n"
+            "Location: \r\n"
+            "Accept-Additions: \r\n"
+            "MMHS-Originator-PLAD: \r\n"
+            "Original-Sender: \r\n"
+            "Original-Sender:\r\n"
+            "PICS-Label:\r\n"
+            " 	\r\n"
+            "If: @ÁP\\ÖÃ†ü\\|–E\r\n"
+            "MMHS-Exempted-Address:\r\n"
+            "Injection-Info: \r\n"
+            "Contetn-Length: 0\r\n"
+            "\r\n"
+            ), p, ec);
+        BEAST_EXPECT(ec);
+    }
+
+    //--------------------------------------------------------------------------
+
+    void
     run() override
     {
         testFlatten();
@@ -1122,6 +1156,7 @@ public:
         testIssue430();
         testIssue452();
         testIssue496();
+        testFuzz1();
     }
 };
 

--- a/test/http/doc_snippets.cpp
+++ b/test/http/doc_snippets.cpp
@@ -7,6 +7,7 @@
 
 #include <beast/core.hpp>
 #include <boost/asio.hpp>
+#include <boost/config.hpp>
 #include <iostream>
 #include <thread>
 
@@ -191,7 +192,7 @@ print_response(SyncReadStream& stream)
 
 //]
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 //[http_snippet_14
 
 template<bool isRequest, class Body, class Fields>
@@ -257,7 +258,7 @@ print(message<isRequest, Body, Fields> const& m)
 
 //]
 
-#ifdef _MSC_VER
+#if BOOST_MSVC
 //[http_snippet_16
 
 template<bool isRequest, class Body, class Fields>

--- a/test/http/serializer.cpp
+++ b/test/http/serializer.cpp
@@ -27,8 +27,10 @@ public:
                 boost::asio::const_buffers_1;
 
             template<bool isRequest, class Fields>
-            reader(message<isRequest, const_body, Fields> const&,
-                error_code&);
+            reader(message<isRequest, const_body, Fields> const&);
+
+            void
+            init(error_code& ec);
 
             boost::optional<std::pair<const_buffers_type, bool>>
             get(error_code&);
@@ -45,8 +47,10 @@ public:
                 boost::asio::const_buffers_1;
 
             template<bool isRequest, class Fields>
-            reader(message<isRequest, mutable_body, Fields>&,
-                error_code&);
+            reader(message<isRequest, mutable_body, Fields>&);
+
+            void
+            init(error_code& ec);
 
             boost::optional<std::pair<const_buffers_type, bool>>
             get(error_code&);
@@ -55,6 +59,7 @@ public:
 
     BOOST_STATIC_ASSERT(std::is_const<  serializer<
         true, const_body>::value_type>::value);
+
     BOOST_STATIC_ASSERT(! std::is_const<serializer<
         true, mutable_body>::value_type>::value);
 

--- a/test/http/serializer.cpp
+++ b/test/http/serializer.cpp
@@ -17,6 +17,63 @@ namespace http {
 class serializer_test : public beast::unit_test::suite
 {
 public:
+    struct const_body
+    {
+        struct value_type{};
+
+        struct reader
+        {
+            using const_buffers_type =
+                boost::asio::const_buffers_1;
+
+            template<bool isRequest, class Fields>
+            reader(message<isRequest, const_body, Fields> const&,
+                error_code&);
+
+            boost::optional<std::pair<const_buffers_type, bool>>
+            get(error_code&);
+        };
+    };
+
+    struct mutable_body
+    {
+        struct value_type{};
+
+        struct reader
+        {
+            using const_buffers_type =
+                boost::asio::const_buffers_1;
+
+            template<bool isRequest, class Fields>
+            reader(message<isRequest, mutable_body, Fields>&,
+                error_code&);
+
+            boost::optional<std::pair<const_buffers_type, bool>>
+            get(error_code&);
+        };
+    };
+
+    BOOST_STATIC_ASSERT(std::is_const<  serializer<
+        true, const_body>::value_type>::value);
+    BOOST_STATIC_ASSERT(! std::is_const<serializer<
+        true, mutable_body>::value_type>::value);
+
+    BOOST_STATIC_ASSERT(std::is_constructible<
+        serializer<true, const_body>,
+        message   <true, const_body>&>::value);
+
+    BOOST_STATIC_ASSERT(std::is_constructible<
+        serializer<true, const_body>,
+        message   <true, const_body> const&>::value);
+
+    BOOST_STATIC_ASSERT(std::is_constructible<
+        serializer<true, mutable_body>,
+        message   <true, mutable_body>&>::value);
+
+    BOOST_STATIC_ASSERT(! std::is_constructible<
+        serializer<true, mutable_body>,
+        message   <true, mutable_body> const&>::value);
+
     struct lambda
     {
         std::size_t size;

--- a/test/http/write.cpp
+++ b/test/http/write.cpp
@@ -47,13 +47,18 @@ public:
 
             template<bool isRequest, class Allocator>
             explicit
-            reader(message<isRequest, unsized_body,
-                    Allocator> const& msg, error_code &ec)
+            reader(message<isRequest,
+                    unsized_body, Allocator> const& msg)
                 : body_(msg.body)
+            {
+            }
+
+            void
+            init(error_code& ec)
             {
                 ec.assign(0, ec.category());
             }
-            
+
             boost::optional<std::pair<const_buffers_type, bool>>
             get(error_code& ec)
             {
@@ -87,9 +92,14 @@ public:
 
             template<bool isRequest, class Fields>
             explicit
-            reader(message<isRequest, test_body,
-                    Fields> const& msg, error_code& ec)
+            reader(message<isRequest,
+                    test_body, Fields> const& msg)
                 : body_(msg.body)
+            {
+            }
+
+            void
+            init(error_code& ec)
             {
                 ec.assign(0, ec.category());
             }
@@ -219,9 +229,14 @@ public:
 
             template<bool isRequest, class Allocator>
             explicit
-            reader(message<isRequest, fail_body,
-                    Allocator> const& msg, error_code& ec)
+            reader(message<isRequest,
+                    fail_body, Allocator> const& msg)
                 : body_(msg.body)
+            {
+            }
+
+            void
+            init(error_code& ec)
             {
                 body_.fc_.fail(ec);
             }

--- a/test/http/write.cpp
+++ b/test/http/write.cpp
@@ -811,8 +811,16 @@ public:
 
     void run() override
     {
-        yield_to([&](yield_context yield){ testAsyncWrite(yield); });
-        yield_to([&](yield_context yield){ testFailures(yield); });
+        yield_to(
+            [&](yield_context yield)
+            {
+                testAsyncWrite(yield);
+            });
+        yield_to(
+            [&](yield_context yield)
+            {
+                testFailures(yield);
+            });
         testOutput();
         test_std_ostream();
         testIoService();

--- a/test/websocket/doc_snippets.cpp
+++ b/test/websocket/doc_snippets.cpp
@@ -217,7 +217,7 @@ boost::asio::ip::tcp::socket sock{ios};
 } // fxx()
 
 // workaround for https://github.com/chriskohlhoff/asio/issues/112
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 //[ws_snippet_21
 void echo(stream<boost::asio::ip::tcp::socket>& ws,
     multi_buffer& buffer, boost::asio::yield_context yield)


### PR DESCRIPTION
* Always go through write_some
* Use Boost.Config
* BodyReader may construct from a non-const message
* Add serializer::get
* Add serializer::chunked
* Serializer members are not const
* serializing file_body is not const
* Add file_body_win32
* Fix parse illegal characters in obs-fold

API Changes:

* Rename to serializer::keep_alive
* BodyReader, BodyWriter use two-phase init

Actions Required:

* Use serializer::keep_alive instead of serializer::close and
  take the logical NOT of the return value.

* Modify instances of user-defined BodyReader and BodyWriter
  types to perfrom two-phase initialization, as per the
  updated documented type requirements.

Documentation preview:
http://vinniefalco.github.io/stage/beast/v76