### PR TITLE
beast::detail::is_invocable: Move Only Parameters

### DIFF
--- a/include/beast/core/detail/type_traits.hpp
+++ b/include/beast/core/detail/type_traits.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <type_traits>
 #include <string>
+#include <utility>
 
 // A few workarounds to keep things working
 
@@ -108,7 +109,7 @@ template<class R, class C, class ...A>
 auto
 is_invocable_test(C&& c, int, A&& ...a)
     -> decltype(std::is_convertible<
-        decltype(c(a...)), R>::value ||
+        decltype(c(std::forward<A>(a)...)), R>::value ||
             std::is_same<R, void>::value,
                 std::true_type());
 

--- a/test/core/type_traits.cpp
+++ b/test/core/type_traits.cpp
@@ -11,6 +11,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/streambuf.hpp>
 #include <boost/asio/detail/consuming_buffers.hpp>
+#include <memory>
 
 namespace beast {
 
@@ -37,6 +38,11 @@ struct is_invocable_udt3
     int operator()(int);
 };
 
+struct is_invocable_udt4
+{
+    void operator()(std::unique_ptr<int>);
+};
+
 #ifndef __INTELLISENSE__
 // VFALCO Fails to compile with Intellisense
 BOOST_STATIC_ASSERT(is_invocable<is_invocable_udt1, void(int)>::value);
@@ -46,6 +52,7 @@ BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt1, void(void)>::value);
 BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt2, int(void)>::value);
 BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt2, void(void)>::value);
 BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt3 const, int(int)>::value);
+BOOST_STATIC_ASSERT(is_invocable<is_invocable_udt4, void(std::unique_ptr<int>)>::value);
 #endif
 
 //


### PR DESCRIPTION
Previously reported that function objects taking move only types by value were not invocable.