### PR TITLE
Version 82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 
 WebSocket
 
-* websocket::stream tidying
+* stream tidying
 * Add rd_close_ to websocket stream state
+* stream uses flat_buffer
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ WebSocket
 * stream uses flat_buffer
 * accept requires a message
 
+API Changes:
+
+* Rename to flat_static_buffer and flat_static_buffer_base
+
+Actions Required:
+
+* Rename static_buffer to flat_static_buffer_base
+* Rename static_buffer_n to flat_static_buffer
+
 --------------------------------------------------------------------------------
 
 Version 81:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Documentation tidying
+* is_invocable works with move-only types
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 * Documentation tidying
 * is_invocable works with move-only types
+
+WebSocket
+
 * websocket::stream tidying
+* Add rd_close_ to websocket stream state
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Documentation tidying
 * is_invocable works with move-only types
+* Use std::function and reference wrapper
 
 WebSocket
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ WebSocket
 * Add rd_close_ to websocket stream state
 * stream uses flat_buffer
 * accept requires a message
+* Add wstest benchmark tool
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 * Documentation tidying
 * is_invocable works with move-only types
 * Use std::function and reference wrapper
+* Add session_alloc to example/common
 
 WebSocket
 
@@ -203,7 +204,6 @@ HTTP:
 WebSocket:
 
 * Add websocket-server-async example
-
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * is_invocable works with move-only types
 * Use std::function and reference wrapper
 * Add session_alloc to example/common
+* Silence spurious warning
 
 WebSocket
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Documentation tidying
+
+--------------------------------------------------------------------------------
+
 Version 81:
 
 * Pass string_view by value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Documentation tidying
 * is_invocable works with move-only types
+* websocket::stream tidying
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ WebSocket
 * stream tidying
 * Add rd_close_ to websocket stream state
 * stream uses flat_buffer
+* accept requires a message
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Version 82:
+
 * Documentation tidying
 * is_invocable works with move-only types
 * Use std::function and reference wrapper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 81)
+project (Beast VERSION 82)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/00_main.qbk
+++ b/doc/qbk/00_main.qbk
@@ -75,8 +75,8 @@
 [def __multi_buffer__           [link beast.ref.beast__multi_buffer `multi_buffer`]]
 [def __parser__                 [link beast.ref.beast__http__parser `parser`]]
 [def __serializer__             [link beast.ref.beast__http__serializer `serializer`]]
-[def __static_buffer__          [link beast.ref.beast__static_buffer `static_buffer`]]
-[def __static_buffer_n__        [link beast.ref.beast__static_buffer_n `static_buffer_n`]]
+[def __flat_static_buffer__      [link beast.ref.beast__flat_static_buffer `flat_static_buffer`]]
+[def __flat_static_buffer_base__ [link beast.ref.beast__flat_static_buffer_base `flat_static_buffer_base`]]
 
 [import ../../example/common/detect_ssl.hpp]
 [import ../../example/doc/http_examples.hpp]

--- a/doc/qbk/03_core/3_buffers.qbk
+++ b/doc/qbk/03_core/3_buffers.qbk
@@ -62,9 +62,10 @@ of scenarios:
     [link beast.ref.beast__basic_flat_buffer `basic_flat_buffer`]
 ][
     Guarantees that input and output areas are buffer sequences with
-    length one. Upon construction an optional upper limit to the total
-    size of the input and output areas may be set. The basic container
-    is an
+    length one.
+    Upon construction an optional upper limit to the total size of the
+    input and output areas may be set.
+    The basic container is an
     [@http://en.cppreference.com/w/cpp/concept/AllocatorAwareContainer [*AllocatorAwareContainer]].
 ]]
 [[
@@ -73,14 +74,16 @@ of scenarios:
 ][
     Uses a sequence of one or more character arrays of varying sizes.
     Additional character array objects are appended to the sequence to
-    accommodate changes in the size of the character sequence. The basic
-    container is an
+    accommodate changes in the size of the character sequence.
+    The basic container is an
     [@http://en.cppreference.com/w/cpp/concept/AllocatorAwareContainer [*AllocatorAwareContainer]].
 ]]
 [[
-    [link beast.ref.beast__static_buffer `static_buffer`]
-    [link beast.ref.beast__static_buffer `static_buffer_n`]
+    [link beast.ref.beast__flat_static_buffer `flat_static_buffer`]
+    [link beast.ref.beast__flat_static_buffer_base `flat_static_buffer_base`]
 ][
+    Guarantees that input and output areas are buffer sequences with
+    length one.
     Provides the facilities of a dynamic buffer, subject to an upper
     limit placed on the total size of the input and output areas defined
     by a constexpr template parameter. The storage for the sequences are

--- a/doc/qbk/04_http/05_parser_streams.qbk
+++ b/doc/qbk/04_http/05_parser_streams.qbk
@@ -104,9 +104,10 @@ As with message stream operations, parser stream operations require a
 persisted __DynamicBuffer__  for holding unused octets from the stream.
 The basic parser implementation is optimized for the case where this dynamic
 buffer stores its input sequence in a single contiguous memory buffer. It is
-advised to use an instance of __flat_buffer__, __static_buffer__, or
-__static_buffer_n__ for this purpose, although a user defined instance of
-__DynamicBuffer__ which produces input sequences of length one is also suitable.
+advised to use an instance of __flat_buffer__, __flat_static_buffer__, or
+__flat_static_buffer_base__ for this purpose, although a user defined instance
+of __DynamicBuffer__ which produces input sequences of length one is also
+suitable.
 
 The parser contains a message constructed internally. Arguments passed
 to the parser's constructor are forwarded into the message container.

--- a/doc/qbk/07_concepts/DynamicBuffer.qbk
+++ b/doc/qbk/07_concepts/DynamicBuffer.qbk
@@ -129,8 +129,8 @@ In this table:
 * [link beast.ref.beast__basic_multi_buffer `basic_multi_buffer`]
 * [link beast.ref.beast__drain_buffer `drain_buffer`]
 * [link beast.ref.beast__flat_buffer `flat_buffer`]
+* [link beast.ref.beast__flat_static_buffer `flat_static_buffer`]
+* [link beast.ref.beast__flat_static_buffer_base `flat_static_buffer_base`]
 * [link beast.ref.beast__multi_buffer `multi_buffer`]
-* [link beast.ref.beast__static_buffer `static_buffer`]
-* [link beast.ref.beast__static_buffer_n `static_buffer_n`]
 
 [endsect]

--- a/doc/qbk/08_design.qbk
+++ b/doc/qbk/08_design.qbk
@@ -30,7 +30,7 @@ __MutableBufferSequence__ concepts for passing buffers to functions.
 The authors have found the dynamic buffer and buffer sequence interfaces to
 be optimal for interacting with Asio, and for other tasks such as incremental
 parsing of data in buffers (for example, parsing websocket frames stored
-in a [link beast.ref.beast__static_buffer `static_buffer`]).
+in a [link beast.ref.beast__flat_static_buffer `flat_static_buffer`]).
 
 During the development of Beast the authors have studied other software
 packages and in particular the comments left during the Boost Review process

--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -195,6 +195,8 @@
             <member><link linkend="beast.ref.beast__file_stdio">file_stdio</link></member>
             <member><link linkend="beast.ref.beast__file_win32">file_win32</link></member>
             <member><link linkend="beast.ref.beast__flat_buffer">flat_buffer</link></member>
+            <member><link linkend="beast.ref.beast__flat_static_buffer">flat_static_buffer</link></member>
+            <member><link linkend="beast.ref.beast__flat_static_buffer_base">flat_static_buffer_base</link></member>
             <member><link linkend="beast.ref.beast__handler_alloc">handler_alloc</link></member>
             <member><link linkend="beast.ref.beast__handler_ptr">handler_ptr</link></member>
             <member><link linkend="beast.ref.beast__handler_type">handler_type</link></member>
@@ -202,8 +204,6 @@
             <member><link linkend="beast.ref.beast__iless">iless</link></member>
             <member><link linkend="beast.ref.beast__multi_buffer">multi_buffer</link></member>
             <member><link linkend="beast.ref.beast__span">span</link></member>
-            <member><link linkend="beast.ref.beast__static_buffer">static_buffer</link></member>
-            <member><link linkend="beast.ref.beast__static_buffer_n">static_buffer_n</link></member>
             <member><link linkend="beast.ref.beast__static_string">static_string</link></member>
             <member><link linkend="beast.ref.beast__string_param">string_param</link></member>
             <member><link linkend="beast.ref.beast__string_view">string_view</link></member>

--- a/example/common/session_alloc.hpp
+++ b/example/common/session_alloc.hpp
@@ -1,0 +1,477 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BEAST_EXAMPLE_COMMON_SESSION_ALLOC_HPP
+#define BEAST_EXAMPLE_COMMON_SESSION_ALLOC_HPP
+
+#include <boost/asio/handler_alloc_hook.hpp>
+#include <boost/asio/handler_continuation_hook.hpp>
+#include <boost/asio/handler_invoke_hook.hpp>
+#include <boost/assert.hpp>
+#include <boost/intrusive/list.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+#if 1
+#include "extras/beast/unit_test/dstream.hpp"
+#endif
+
+template<class Context>
+class session_alloc_base
+{
+    template<class Handler>
+    class wrapped_handler;
+
+    class pool_t
+    {
+        using hook_type = 
+            boost::intrusive::list_base_hook<
+                boost::intrusive::link_mode<
+                    boost::intrusive::normal_link>>;
+
+        class element : public hook_type
+        {
+            std::size_t size_;
+            std::size_t used_;
+            // add padding here
+        
+        public:
+            explicit
+            element(std::size_t size, std::size_t used)
+                : size_(size)
+                , used_(used)
+            {
+            }
+
+            std::size_t
+            size() const
+            {
+                return size_;
+            }
+
+            std::size_t
+            used() const
+            {
+                return used_;
+            }
+
+            char*
+            end() const
+            {
+                return data() + size_;
+            }
+
+            char*
+            data() const
+            {
+                return const_cast<char*>(
+                    reinterpret_cast<
+                        char const *>(this + 1));
+            }
+        };
+
+        using list_type = typename
+            boost::intrusive::make_list<element,
+                boost::intrusive::constant_time_size<
+                    true>>::type;
+
+        Context* ctx_;
+        std::size_t refs_ = 1;      // shared count
+        std::size_t high_ = 0;      // highest used
+        std::size_t size_ = 0;      // size of buf_
+        char* buf_ = nullptr;       // a large block
+        list_type list_;            // list of allocations
+
+        explicit
+        pool_t(Context* ctx)
+            : ctx_(ctx)
+        {
+        }
+
+    public:
+        static
+        pool_t&
+        construct(Context* ctx);
+
+        ~pool_t();
+
+        pool_t&
+        addref();
+
+        void
+        release();
+
+        void*
+        alloc(std::size_t n);
+
+        void
+        dealloc(void* pv, std::size_t n);
+    };
+
+    pool_t& pool_;
+
+public:
+    session_alloc_base& operator=(session_alloc_base const&) = delete;
+
+    ~session_alloc_base()
+    {
+        pool_.release();
+    }
+
+    session_alloc_base()
+        : pool_(pool_t::construct(nullptr))
+    {
+        static_assert(std::is_same<Context, std::nullptr_t>::value,
+            "Context requirements not met");
+    }
+
+    session_alloc_base(session_alloc_base const& other)
+        : pool_(other.pool_.addref())
+    {
+    }
+
+    template<class DeducedContext, class = typename
+        std::enable_if<! std::is_same<
+            session_alloc_base<Context>,
+            typename std::decay<DeducedContext>::type
+                >::value>::type>
+    explicit
+    session_alloc_base(DeducedContext& ctx)
+        : pool_(pool_t::construct(std::addressof(ctx)))
+    {
+        static_assert(! std::is_same<Context, std::nullptr_t>::value,
+            "Context requirements not met");
+    }
+
+    template<class Handler>
+    wrapped_handler<typename std::decay<Handler>::type>
+    wrap(Handler&& handler)
+    {
+        return wrapped_handler<
+            typename std::decay<Handler>::type>(
+                std::forward<Handler>(handler), *this);
+    }
+
+protected:
+    void*
+    alloc(std::size_t n)
+    {
+        return pool_.alloc(n);
+    }
+
+    void
+    dealloc(void* p, std::size_t n)
+    {
+        pool_.dealloc(p, n);
+    }
+};
+
+//------------------------------------------------------------------------------
+
+template<class T, class Context = std::nullptr_t>
+class session_alloc : public session_alloc_base<Context>
+{
+    template<class U, class C>
+    friend class session_alloc;
+
+public:
+    using value_type = T;
+    using is_always_equal = std::false_type;
+    using pointer = T*;
+    using reference = T&;
+    using const_pointer = T const*;
+    using const_reference = T const&;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    template<class U>
+    struct rebind
+    {
+        using other = session_alloc<U>;
+    };
+
+    session_alloc() = default;
+    session_alloc(session_alloc const&) = default;
+
+    template<class U>
+    session_alloc(session_alloc<U> const& other)
+        : session_alloc_base<Context>(static_cast<
+            session_alloc_base<Context> const&>(other))
+    {
+    }
+
+    explicit
+    session_alloc(Context& ctx)
+        : session_alloc_base<Context>(ctx)
+    {
+    }
+
+    value_type*
+    allocate(size_type n)
+    {
+        return static_cast<value_type*>(
+            this->alloc(n * sizeof(T)));
+    }
+
+    void
+    deallocate(value_type* p, size_type n)
+    {
+        this->dealloc(p, n * sizeof(T));
+    }
+
+#if defined(BOOST_LIBSTDCXX_VERSION) && BOOST_LIBSTDCXX_VERSION < 60000
+    template<class U, class... Args>
+    void
+    construct(U* ptr, Args&&... args)
+    {
+        ::new((void*)ptr) U(std::forward<Args>(args)...);
+    }
+
+    template<class U>
+    void
+    destroy(U* ptr)
+    {
+        ptr->~U();
+    }
+#endif
+
+    template<class U>
+    friend
+    bool
+    operator==(
+        session_alloc const& lhs,
+        session_alloc<U> const& rhs)
+    {
+        return &lhs.pool_ == &rhs.pool_;
+    }
+
+    template<class U>
+    friend
+    bool
+    operator!=(
+        session_alloc const& lhs,
+        session_alloc<U> const& rhs)
+    {
+        return ! (lhs == rhs);
+    }
+};
+
+//------------------------------------------------------------------------------
+
+template<class Context>
+template<class Handler>
+class session_alloc_base<Context>::wrapped_handler
+{
+    Handler h_;
+    session_alloc_base alloc_;
+
+    void*
+    alloc(std::size_t size)
+    {
+        return alloc_.alloc(size);
+    }
+
+    void
+    dealloc(void* p, std::size_t size)
+    {
+        alloc_.dealloc(p, size);
+    }
+
+public:
+    wrapped_handler(wrapped_handler&&) = default;
+    wrapped_handler(wrapped_handler const&) = default;
+
+    template<class DeducedHandler>
+    explicit
+    wrapped_handler(DeducedHandler&& h,
+            session_alloc_base const& alloc)
+        : h_(std::forward<DeducedHandler>(h))
+        , alloc_(alloc)
+    {
+    }
+
+    template<class... Args>
+    void
+    operator()(Args&&... args) const
+    {
+        h_(std::forward<Args>(args)...);
+    }
+
+    friend
+    void*
+    asio_handler_allocate(
+        std::size_t size, wrapped_handler* w)
+    {
+        return w->alloc(size);
+    }
+
+    friend
+    void
+    asio_handler_deallocate(
+        void* p, std::size_t size, wrapped_handler* w)
+    {
+        w->dealloc(p, size);
+    }
+
+    friend
+    bool
+    asio_handler_is_continuation(wrapped_handler* w)
+    {
+        using boost::asio::asio_handler_is_continuation;
+        return asio_handler_is_continuation(std::addressof(w->h_));
+    }
+
+    template<class F>
+    friend
+    void
+    asio_handler_invoke(F&& f, wrapped_handler* w)
+    {
+        using boost::asio::asio_handler_invoke;
+        asio_handler_invoke(
+            f, std::addressof(w->h_));
+    }
+};
+
+//------------------------------------------------------------------------------
+
+template<class Context>
+auto
+session_alloc_base<Context>::
+pool_t::
+construct(Context* ctx) ->
+    pool_t&
+{
+    using boost::asio::asio_handler_allocate;
+    return *new(asio_handler_allocate(
+        sizeof(pool_t), ctx)) pool_t{ctx};
+}
+
+template<class Context>
+session_alloc_base<Context>::
+pool_t::
+~pool_t()
+{
+    BOOST_ASSERT(list_.size() == 0);
+    if(buf_)
+    {
+        using boost::asio::asio_handler_deallocate;
+        asio_handler_deallocate(buf_, size_, ctx_);
+    }
+}
+
+template<class Context>
+auto
+session_alloc_base<Context>::
+pool_t::
+addref() ->
+    pool_t&
+{
+    ++refs_;
+    return *this;
+}
+
+template<class Context>
+void
+session_alloc_base<Context>::
+pool_t::
+release()
+{
+    if(--refs_)
+        return;
+    this->~pool_t();
+    using boost::asio::asio_handler_deallocate;
+    asio_handler_deallocate(this, sizeof(*this), ctx_);
+}
+
+template<class Context>
+void*
+session_alloc_base<Context>::
+pool_t::
+alloc(std::size_t n)
+{
+#if 0
+beast::unit_test::dstream dout{std::cout};
+dout <<
+"n=" << n << ", "
+"list_.size()=" << list_.size() << ", "
+"used=" << (list_.empty() ? 0 : list_.back().used()) << ", "
+"size_=" << size_ << ", "
+"high_=" << high_ <<
+std::endl;
+#endif
+    if(list_.empty() && size_ < high_)
+    {
+        if(buf_)
+        {
+            using boost::asio::asio_handler_deallocate;
+            asio_handler_deallocate(buf_, size_, ctx_);
+        }
+        using boost::asio::asio_handler_allocate;
+        buf_ = reinterpret_cast<char*>(
+            asio_handler_allocate(high_, ctx_));
+        size_ = high_;
+    }
+    if(buf_)
+    {
+        char* end;
+        std::size_t used;
+        if(list_.empty())
+        {
+            end = buf_;
+            used = sizeof(element) + n;
+        }
+        else
+        {
+            end = list_.back().end();
+            used = list_.back().used() +
+                sizeof(element) + n;
+        }
+        if(end >= buf_ && end +
+            sizeof(element) + n <= buf_ + size_)
+        {
+            auto& e = *new(end) element{n, used};
+            list_.push_back(e);
+            high_ = (std::max)(high_, used);
+            return e.data();
+        }
+    }
+    std::size_t const used =
+        sizeof(element) + n + (
+            buf_ && ! list_.empty() ?
+                list_.back().used() : 0);
+    using boost::asio::asio_handler_allocate;
+    auto& e = *new(asio_handler_allocate(
+        sizeof(element) + n, ctx_)) element{n, used};
+    list_.push_back(e);
+    high_ = (std::max)(high_, used);
+    return e.data();
+}
+
+template<class Context>
+void
+session_alloc_base<Context>::
+pool_t::
+dealloc(void* pv, std::size_t n)
+{
+    auto& e = *(reinterpret_cast<element*>(pv) - 1);
+    BOOST_ASSERT(e.size() == n);
+    if( (e.end() > buf_ + size_) ||
+        reinterpret_cast<char*>(&e) < buf_)
+    {
+        list_.erase(list_.iterator_to(e));
+        e.~element();
+        using boost::asio::asio_handler_deallocate;
+        asio_handler_deallocate(
+            &e, sizeof(e) + n, ctx_);
+        return;
+    }
+    list_.erase(list_.iterator_to(e));
+    e.~element();
+}
+
+#endif

--- a/example/http-server-fast/http_server_fast.cpp
+++ b/example/http-server-fast/http_server_fast.cpp
@@ -47,7 +47,7 @@ public:
 
 private:
     using alloc_t = fields_alloc<char>;
-    using request_body_t = http::basic_dynamic_body<beast::static_buffer_n<1024 * 1024>>;
+    using request_body_t = http::basic_dynamic_body<beast::flat_static_buffer<1024 * 1024>>;
 
     // The acceptor used to listen for incoming connections.
     tcp::acceptor& acceptor_;
@@ -59,7 +59,7 @@ private:
     tcp::socket socket_{acceptor_.get_io_service()};
 
     // The buffer for performing reads
-    beast::static_buffer_n<8192> buffer_;
+    beast::flat_static_buffer<8192> buffer_;
 
     // The allocator used for the fields in the request and reply.
     alloc_t alloc_{8192};

--- a/example/server-framework/multi_port.hpp
+++ b/example/server-framework/multi_port.hpp
@@ -54,7 +54,7 @@ class multi_con
     boost::asio::ssl::context& ctx_;
 
     // Holds the data we read during ssl detection
-    beast::static_buffer_n<6> buffer_;
+    beast::flat_static_buffer<6> buffer_;
 
 public:
     // Constructor

--- a/example/websocket-server-async/websocket_server_async.cpp
+++ b/example/websocket-server-async/websocket_server_async.cpp
@@ -202,58 +202,7 @@ class server
             //
             buffer_.consume(buffer_.size());
 
-            // This shows how the server can close the
-            // connection. Alternatively we could call
-            // do_read again and the connection would
-            // stay open until the other side closes it.
-            //
-            do_close();
-        }
-
-        // Sends a websocket close frame
-        void do_close()
-        {
-            // Put the close frame on the timer
-            timer_.expires_from_now(std::chrono::seconds(15));
-
-            // Send the close frame
-            ws_.async_close({},
-                strand_.wrap(std::bind(
-                    &connection::on_close,
-                    shared_from_this(),
-                    std::placeholders::_1)));
-        }
-
-        // Called when writing the close frame completes
-        void on_close(error_code ec)
-        {
-            if(ec)
-                return fail("close", ec);
-
-            on_drain({});
-        }
-
-        // Read and discard any leftover message data
-        void on_drain(error_code ec)
-        {
-            if(ec == websocket::error::closed)
-            {
-                // the connection has been closed gracefully
-                return;
-            }
-
-            if(ec)
-                return fail("drain", ec);
-
-            // WebSocket says that to close a connection you have
-            // to keep reading messages until you receive a close frame.
-            // Beast delivers the close frame as an error from read.
-            //
-            ws_.async_read(drain_,
-                strand_.wrap(std::bind(
-                    &connection::on_drain,
-                    shared_from_this(),
-                    std::placeholders::_1)));
+            do_read();
         }
 
         // Pretty-print an error to the log

--- a/include/beast/core.hpp
+++ b/include/beast/core.hpp
@@ -31,7 +31,7 @@
 #include <beast/core/ostream.hpp>
 #include <beast/core/read_size.hpp>
 #include <beast/core/span.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/core/static_string.hpp>
 #include <beast/core/string.hpp>
 #include <beast/core/string_param.hpp>

--- a/include/beast/core/detail/type_traits.hpp
+++ b/include/beast/core/detail/type_traits.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <type_traits>
 #include <string>
+#include <utility>
 
 // A few workarounds to keep things working
 
@@ -108,7 +109,7 @@ template<class R, class C, class ...A>
 auto
 is_invocable_test(C&& c, int, A&& ...a)
     -> decltype(std::is_convertible<
-        decltype(c(a...)), R>::value ||
+        decltype(c(std::forward<A>(a)...)), R>::value ||
             std::is_same<R, void>::value,
                 std::true_type());
 

--- a/include/beast/core/flat_static_buffer.hpp
+++ b/include/beast/core/flat_static_buffer.hpp
@@ -5,8 +5,8 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifndef BEAST_STATIC_BUFFER_HPP
-#define BEAST_STATIC_BUFFER_HPP
+#ifndef BEAST_FLAT_STATIC_BUFFER_HPP
+#define BEAST_FLAT_STATIC_BUFFER_HPP
 
 #include <beast/config.hpp>
 #include <boost/asio/buffer.hpp>
@@ -16,22 +16,24 @@
 
 namespace beast {
 
-/** A @b DynamicBuffer with a fixed size internal buffer.
+/** A flat @b DynamicBuffer with a fixed size internal buffer.
 
+    Buffer sequences returned by @ref data and @ref prepare
+    will always be of length one.
     Ownership of the underlying storage belongs to the derived class.
 
     @note Variables are usually declared using the template class
-    @ref static_buffer_n; however, to reduce the number of instantiations
+    @ref flat_static_buffer; however, to reduce the number of instantiations
     of template functions receiving static stream buffer arguments in a
     deduced context, the signature of the receiving function should use
-    @ref static_buffer.
+    @ref flat_static_buffer_base.
 
-    When used with @ref static_buffer_n this implements a dynamic
+    When used with @ref flat_static_buffer this implements a dynamic
     buffer using no memory allocations.
 
-    @see @ref static_buffer_n
+    @see @ref flat_static_buffer
 */
-class static_buffer
+class flat_static_buffer_base
 {
     char* begin_;
     char* in_;
@@ -39,17 +41,23 @@ class static_buffer
     char* last_;
     char* end_;
 
-    static_buffer(static_buffer const& other) = delete;
-    static_buffer& operator=(static_buffer const&) = delete;
+    flat_static_buffer_base(flat_static_buffer_base const& other) = delete;
+    flat_static_buffer_base& operator=(flat_static_buffer_base const&) = delete;
 
 public:
-    /// The type used to represent the input sequence as a list of buffers.
+    /** The type used to represent the input sequence as a list of buffers.
+
+        This buffer sequence is guaranteed to have length 1.
+    */
     using const_buffers_type = boost::asio::const_buffers_1;
 
-    /// The type used to represent the output sequence as a list of buffers.
+    /** The type used to represent the output sequence as a list of buffers.
+
+        This buffer sequence is guaranteed to have length 1.
+    */
     using mutable_buffers_type = boost::asio::mutable_buffers_1;
 
-    /** Constructor.
+    /** Constructor
 
         This creates a dynamic buffer using the provided storage area.
 
@@ -57,7 +65,7 @@ public:
 
         @param n The number of valid bytes pointed to by `p`.
     */
-    static_buffer(void* p, std::size_t n)
+    flat_static_buffer_base(void* p, std::size_t n)
     {
         reset_impl(p, n);
     }
@@ -120,13 +128,13 @@ public:
     }
 
 protected:
-    /** Default constructor.
+    /** Constructor
 
         The buffer will be in an undefined state. It is necessary
         for the derived class to call @ref reset in order to
         initialize the object.
     */
-    static_buffer();
+    flat_static_buffer_base();
 
     /** Reset the pointed-to buffer.
 
@@ -168,43 +176,45 @@ private:
 
 /** A @b DynamicBuffer with a fixed size internal buffer.
 
+    Buffer sequences returned by @ref data and @ref prepare
+    will always be of length one.
     This implements a dynamic buffer using no memory allocations.
 
     @tparam N The number of bytes in the internal buffer.
 
     @note To reduce the number of template instantiations when passing
     objects of this type in a deduced context, the signature of the
-    receiving function should use @ref static_buffer instead.
+    receiving function should use @ref flat_static_buffer_base instead.
 
-    @see @ref static_buffer
+    @see @ref flat_static_buffer_base
 */
 template<std::size_t N>
-class static_buffer_n : public static_buffer
+class flat_static_buffer : public flat_static_buffer_base
 {
     char buf_[N];
 
 public:
-    /// Copy constructor
-    static_buffer_n(static_buffer_n const&);
+    /// Constructor
+    flat_static_buffer(flat_static_buffer const&);
 
-    /// Copy assignment
-    static_buffer_n& operator=(static_buffer_n const&);
-
-    /// Construct a static buffer.
-    static_buffer_n()
-        : static_buffer(buf_, N)
+    /// Constructor
+    flat_static_buffer()
+        : flat_static_buffer_base(buf_, N)
     {
     }
 
-    /// Returns the @ref static_buffer portion of this object
-    static_buffer&
+    /// Assignment
+    flat_static_buffer& operator=(flat_static_buffer const&);
+
+    /// Returns the @ref flat_static_buffer_base portion of this object
+    flat_static_buffer_base&
     base()
     {
         return *this;
     }
 
-    /// Returns the @ref static_buffer portion of this object
-    static_buffer const&
+    /// Returns the @ref flat_static_buffer_base portion of this object
+    flat_static_buffer_base const&
     base() const
     {
         return *this;
@@ -213,6 +223,6 @@ public:
 
 } // beast
 
-#include <beast/core/impl/static_buffer.ipp>
+#include <beast/core/impl/flat_static_buffer.ipp>
 
 #endif

--- a/include/beast/core/impl/flat_static_buffer.ipp
+++ b/include/beast/core/impl/flat_static_buffer.ipp
@@ -5,8 +5,8 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifndef BEAST_IMPL_STATIC_BUFFER_IPP
-#define BEAST_IMPL_STATIC_BUFFER_IPP
+#ifndef BEAST_IMPL_FLAT_STATIC_BUFFER_IPP
+#define BEAST_IMPL_FLAT_STATIC_BUFFER_IPP
 
 #include <beast/core/detail/type_traits.hpp>
 #include <boost/asio/buffer.hpp>
@@ -25,7 +25,7 @@ namespace beast {
 
 inline
 auto
-static_buffer::
+flat_static_buffer_base::
 data() const ->
     const_buffers_type
 {
@@ -34,7 +34,7 @@ data() const ->
 
 inline
 auto
-static_buffer::
+flat_static_buffer_base::
 prepare(std::size_t n) ->
     mutable_buffers_type
 {
@@ -43,7 +43,7 @@ prepare(std::size_t n) ->
 
 inline
 void
-static_buffer::
+flat_static_buffer_base::
 reset(void* p, std::size_t n)
 {
     reset_impl(p, n);
@@ -51,7 +51,7 @@ reset(void* p, std::size_t n)
 
 template<class>
 void
-static_buffer::
+flat_static_buffer_base::
 reset_impl(void* p, std::size_t n)
 {
     begin_ =
@@ -64,7 +64,7 @@ reset_impl(void* p, std::size_t n)
 
 template<class>
 auto
-static_buffer::
+flat_static_buffer_base::
 prepare_impl(std::size_t n) ->
     mutable_buffers_type
 {
@@ -87,7 +87,7 @@ prepare_impl(std::size_t n) ->
 
 template<class>
 void
-static_buffer::
+flat_static_buffer_base::
 consume_impl(std::size_t n)
 {
     if(n >= size())
@@ -102,9 +102,9 @@ consume_impl(std::size_t n)
 //------------------------------------------------------------------------------
 
 template<std::size_t N>
-static_buffer_n<N>::
-static_buffer_n(static_buffer_n const& other)
-    : static_buffer(buf_, N)
+flat_static_buffer<N>::
+flat_static_buffer(flat_static_buffer const& other)
+    : flat_static_buffer_base(buf_, N)
 {
     using boost::asio::buffer_copy;
     this->commit(buffer_copy(
@@ -113,9 +113,9 @@ static_buffer_n(static_buffer_n const& other)
 
 template<std::size_t N>
 auto
-static_buffer_n<N>::
-operator=(static_buffer_n const& other) ->
-    static_buffer_n<N>&
+flat_static_buffer<N>::
+operator=(flat_static_buffer const& other) ->
+    flat_static_buffer<N>&
 {
     using boost::asio::buffer_copy;
     this->consume(this->size());

--- a/include/beast/core/string_param.hpp
+++ b/include/beast/core/string_param.hpp
@@ -24,7 +24,17 @@ namespace beast {
     passed in contexts where a string is expected. The conversion
     to string is made using `operator<<` to a non-dynamically
     allocated static buffer if possible, else to a `std::string`
-    on overflow. 
+    on overflow.
+
+    To use it, modify your function signature to accept
+    `string_param` and then extract the string inside the
+    function:
+    @code
+    void print(string_param s)
+    {
+        std::cout << s.str();
+    }
+    @endcode
 */
 class string_param
 {
@@ -94,6 +104,13 @@ public:
     */
     template<class... Args>
     string_param(Args const&... args);
+
+    /// Returns the contained string
+    string_view
+    str() const
+    {
+        return sv_;
+    }
 
     /// Implicit conversion to @ref string_view
     operator string_view const() const

--- a/include/beast/http/basic_parser.hpp
+++ b/include/beast/http/basic_parser.hpp
@@ -401,7 +401,7 @@ public:
         @b ConstBufferSequence that represents the next chunk of
         message data. If the length of this buffer sequence is
         one, the implementation will not allocate additional memory.
-        The class @ref flat_buffer is provided as one way to
+        The class @ref beast::flat_buffer is provided as one way to
         meet this requirement
 
         @param ec Set to the error, if any occurred.

--- a/include/beast/http/detail/basic_parser.hpp
+++ b/include/beast/http/detail/basic_parser.hpp
@@ -616,7 +616,7 @@ protected:
         }
         name = make_string(first, p);
         ++p; // eat ':'
-        char const* token_last;
+        char const* token_last = nullptr;
         for(;;)
         {
             // eat leading ' ' and '\t'

--- a/include/beast/http/impl/parser.ipp
+++ b/include/beast/http/impl/parser.ipp
@@ -16,35 +16,9 @@ namespace http {
 
 template<bool isRequest, class Body, class Allocator>
 parser<isRequest, Body, Allocator>::
-~parser()
-{
-    if(cb_h_)
-        cb_h_->~cb_h_t();
-    if(cb_b_)
-        cb_b_->~cb_b_t();
-}
-
-template<bool isRequest, class Body, class Allocator>
-parser<isRequest, Body, Allocator>::
 parser()
     : wr_(m_)
 {
-}
-
-template<bool isRequest, class Body, class Allocator>
-parser<isRequest, Body, Allocator>::
-parser(parser&& other)
-    : base_type(std::move(other))
-    , m_(other.m_)
-    , wr_(other.wr_)
-    , wr_inited_(other.wr_inited_)
-{
-    if(other.cb_h_)
-        cb_h_ = other.cb_h_->move(
-            &cb_h_buf_);
-    if(other.cb_b_)
-        cb_b_ = other.cb_h_->move(
-            &cb_b_buf_);
 }
 
 template<bool isRequest, class Body, class Allocator>
@@ -69,42 +43,6 @@ parser(parser<isRequest, OtherBody, Allocator>&& other,
     if(other.wr_inited_)
         BOOST_THROW_EXCEPTION(std::invalid_argument{
             "moved-from parser has a body"});
-}
-
-template<bool isRequest, class Body, class Allocator>
-template<class Callback>
-void
-parser<isRequest, Body, Allocator>::
-on_chunk_header(Callback& cb)
-{
-    // Callback may not be constant, caller is responsible for
-    // managing the lifetime of the callback. Copies are not made.
-    BOOST_STATIC_ASSERT(! std::is_const<Callback>::value);
-
-    // Can't set the callback after receiving any chunk data!
-    BOOST_ASSERT(! wr_inited_);
-
-    if(cb_h_)
-        cb_h_->~cb_h_t();
-    cb_h_ = new(&cb_h_buf_) cb_h_t_impl<Callback>(cb);
-}
-
-template<bool isRequest, class Body, class Allocator>
-template<class Callback>
-void
-parser<isRequest, Body, Allocator>::
-on_chunk_body(Callback& cb)
-{
-    // Callback may not be constant, caller is responsible for
-    // managing the lifetime of the callback. Copies are not made.
-    BOOST_STATIC_ASSERT(! std::is_const<Callback>::value);
-
-    // Can't set the callback after receiving any chunk data!
-    BOOST_ASSERT(! wr_inited_);
-
-    if(cb_b_)
-        cb_b_->~cb_b_t();
-    cb_b_ = new(&cb_b_buf_) cb_b_t_impl<Callback>(cb);
 }
 
 } // http

--- a/include/beast/version.hpp
+++ b/include/beast/version.hpp
@@ -18,7 +18,7 @@
     This is a simple integer that is incremented by one every time
     a set of code changes is merged to the master or develop branch.
 */
-#define BEAST_VERSION 81
+#define BEAST_VERSION 82
 
 #define BEAST_VERSION_STRING "Beast/" BOOST_STRINGIZE(BEAST_VERSION)
 

--- a/include/beast/websocket/detail/frame.hpp
+++ b/include/beast/websocket/detail/frame.hpp
@@ -11,7 +11,7 @@
 #include <beast/websocket/rfc6455.hpp>
 #include <beast/websocket/detail/utf8_checker.hpp>
 #include <beast/core/consuming_buffers.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/core/static_string.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/assert.hpp>
@@ -108,11 +108,11 @@ struct frame_header
 
 // holds the largest possible frame header
 using fh_streambuf =
-    static_buffer_n<14>;
+    flat_static_buffer<14>;
 
 // holds the largest possible control frame
 using frame_streambuf =
-    static_buffer_n< 2 + 8 + 4 + 125 >;
+    flat_static_buffer< 2 + 8 + 4 + 125 >;
 
 inline
 bool constexpr

--- a/include/beast/websocket/impl/accept.ipp
+++ b/include/beast/websocket/impl/accept.ipp
@@ -42,24 +42,22 @@ class stream<NextLayer>::response_op
         response_type res;
         int state = 0;
 
-        template<class Allocator, class Decorator>
-        data(Handler&, stream<NextLayer>& ws_, http::header<
-            true, http::basic_fields<Allocator>> const& req,
-                Decorator const& decorator,
-                    bool cont_)
+        template<class Body, class Allocator, class Decorator>
+        data(Handler&, stream<NextLayer>& ws_, http::request<
+            Body, http::basic_fields<Allocator>> const& req,
+                Decorator const& decorator, bool cont_)
             : cont(cont_)
             , ws(ws_)
             , res(ws_.build_response(req, decorator))
         {
         }
 
-        template<class Allocator,
+        template<class Body, class Allocator,
             class Buffers, class Decorator>
-        data(Handler&, stream<NextLayer>& ws_, http::header<
-            true, http::basic_fields<Allocator>> const& req,
-                Buffers const& buffers,
-                    Decorator const& decorator,
-                        bool cont_)
+        data(Handler&, stream<NextLayer>& ws_, http::request<
+            Body, http::basic_fields<Allocator>> const& req,
+                Buffers const& buffers, Decorator const& decorator,
+                    bool cont_)
             : cont(cont_)
             , ws(ws_)
             , res(ws_.build_response(req, decorator))
@@ -443,10 +441,10 @@ accept_ex(ConstBufferSequence const& buffers,
 }
 
 template<class NextLayer>
-template<class Allocator>
+template<class Body, class Allocator>
 void
 stream<NextLayer>::
-accept(http::header<true,
+accept(http::request<Body,
     http::basic_fields<Allocator>> const& req)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -458,10 +456,11 @@ accept(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator, class ResponseDecorator>
+template<class Body,
+    class Allocator, class ResponseDecorator>
 void
 stream<NextLayer>::
-accept_ex(http::header<true,
+accept_ex(http::request<Body,
     http::basic_fields<Allocator>> const& req,
     ResponseDecorator const& decorator)
 {
@@ -477,10 +476,10 @@ accept_ex(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator>
+template<class Body, class Allocator>
 void
 stream<NextLayer>::
-accept(http::header<true,
+accept(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         error_code& ec)
 {
@@ -491,10 +490,11 @@ accept(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator, class ResponseDecorator>
+template<class Body, class Allocator,
+    class ResponseDecorator>
 void
 stream<NextLayer>::
-accept_ex(http::header<true,
+accept_ex(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ResponseDecorator const& decorator, error_code& ec)
 {
@@ -508,10 +508,11 @@ accept_ex(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator, class ConstBufferSequence>
+template<class Body, class Allocator,
+    class ConstBufferSequence>
 void
 stream<NextLayer>::
-accept(http::header<true,
+accept(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ConstBufferSequence const& buffers)
 {
@@ -527,11 +528,11 @@ accept(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator,
+template<class Body, class Allocator,
     class ConstBufferSequence, class ResponseDecorator>
 void
 stream<NextLayer>::
-accept_ex(http::header<true,
+accept_ex(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ConstBufferSequence const& buffers,
             ResponseDecorator const& decorator)
@@ -551,11 +552,12 @@ accept_ex(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator, class ConstBufferSequence>
+template<class Body, class Allocator,
+    class ConstBufferSequence>
 void
 stream<NextLayer>::
-accept(http::header<true,
-    Allocator> const& req,
+accept(http::request<Body,
+    http::basic_fields<Allocator>> const& req,
         ConstBufferSequence const& buffers, error_code& ec)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -573,11 +575,11 @@ accept(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator,
+template<class Body, class Allocator,
     class ConstBufferSequence, class ResponseDecorator>
 void
 stream<NextLayer>::
-accept_ex(http::header<true,
+accept_ex(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ConstBufferSequence const& buffers,
             ResponseDecorator const& decorator,
@@ -696,11 +698,12 @@ async_accept_ex(ConstBufferSequence const& buffers,
 }
 
 template<class NextLayer>
-template<class Allocator, class AcceptHandler>
+template<class Body, class Allocator,
+    class AcceptHandler>
 async_return_type<
     AcceptHandler, void(error_code)>
 stream<NextLayer>::
-async_accept(http::header<true,
+async_accept(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         AcceptHandler&& handler)
 {
@@ -719,12 +722,12 @@ async_accept(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator,
+template<class Body, class Allocator,
     class ResponseDecorator, class AcceptHandler>
 async_return_type<
     AcceptHandler, void(error_code)>
 stream<NextLayer>::
-async_accept_ex(http::header<true,
+async_accept_ex(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ResponseDecorator const& decorator, AcceptHandler&& handler)
 {
@@ -746,12 +749,12 @@ async_accept_ex(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator,
+template<class Body, class Allocator,
     class ConstBufferSequence, class AcceptHandler>
 async_return_type<
     AcceptHandler, void(error_code)>
 stream<NextLayer>::
-async_accept(http::header<true,
+async_accept(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ConstBufferSequence const& buffers,
             AcceptHandler&& handler)
@@ -774,12 +777,13 @@ async_accept(http::header<true,
 }
 
 template<class NextLayer>
-template<class Allocator, class ConstBufferSequence,
-    class ResponseDecorator, class AcceptHandler>
+template<class Body, class Allocator,
+    class ConstBufferSequence, class ResponseDecorator,
+        class AcceptHandler>
 async_return_type<
     AcceptHandler, void(error_code)>
 stream<NextLayer>::
-async_accept_ex(http::header<true,
+async_accept_ex(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         ConstBufferSequence const& buffers,
             ResponseDecorator const& decorator,

--- a/include/beast/websocket/impl/close.ipp
+++ b/include/beast/websocket/impl/close.ipp
@@ -9,7 +9,7 @@
 #define BEAST_WEBSOCKET_IMPL_CLOSE_IPP
 
 #include <beast/core/handler_ptr.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/core/type_traits.hpp>
 #include <beast/core/detail/config.hpp>
 #include <boost/asio/handler_alloc_hook.hpp>
@@ -42,7 +42,7 @@ class stream<NextLayer>::close_op
             , cr(cr_)
         {
             ws.template write_close<
-                static_buffer>(fb, cr);
+                flat_static_buffer_base>(fb, cr);
         }
     };
 
@@ -227,7 +227,7 @@ close(close_reason const& cr, error_code& ec)
     }
     wr_close_ = true;
     detail::frame_streambuf fb;
-    write_close<static_buffer>(fb, cr);
+    write_close<flat_static_buffer_base>(fb, cr);
     boost::asio::write(stream_, fb.data(), ec);
     failed_ = !!ec;
 }

--- a/include/beast/websocket/impl/ping.ipp
+++ b/include/beast/websocket/impl/ping.ipp
@@ -43,7 +43,7 @@ class stream<NextLayer>::ping_op
             using boost::asio::buffer;
             using boost::asio::buffer_copy;
             ws.template write_ping<
-                static_buffer>(fb, op_, payload);
+                flat_static_buffer_base>(fb, op_, payload);
         }
     };
 
@@ -234,7 +234,7 @@ stream<NextLayer>::
 ping(ping_data const& payload, error_code& ec)
 {
     detail::frame_streambuf db;
-    write_ping<static_buffer>(
+    write_ping<flat_static_buffer_base>(
         db, detail::opcode::ping, payload);
     boost::asio::write(stream_, db.data(), ec);
 }
@@ -256,7 +256,7 @@ stream<NextLayer>::
 pong(ping_data const& payload, error_code& ec)
 {
     detail::frame_streambuf db;
-    write_ping<static_buffer>(
+    write_ping<flat_static_buffer_base>(
         db, detail::opcode::pong, payload);
     boost::asio::write(stream_, db.data(), ec);
 }

--- a/include/beast/websocket/impl/read.ipp
+++ b/include/beast/websocket/impl/read.ipp
@@ -11,7 +11,7 @@
 #include <beast/websocket/teardown.hpp>
 #include <beast/core/buffer_prefix.hpp>
 #include <beast/core/handler_ptr.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/core/type_traits.hpp>
 #include <beast/core/detail/clamp.hpp>
 #include <beast/core/detail/config.hpp>
@@ -445,7 +445,7 @@ operator()(error_code ec,
                         d.state = do_read_fh;
                         break;
                     }
-                    d.ws.template write_ping<static_buffer>(
+                    d.ws.template write_ping<flat_static_buffer_base>(
                         d.fb, detail::opcode::pong, payload);
                     if(d.ws.wr_block_)
                     {
@@ -492,7 +492,7 @@ operator()(error_code ec,
                         cr.reason = "";
                         d.fb.consume(d.fb.size());
                         d.ws.template write_close<
-                            static_buffer>(d.fb, cr);
+                            flat_static_buffer_base>(d.fb, cr);
                         if(d.ws.wr_block_)
                         {
                             // suspend
@@ -619,7 +619,7 @@ operator()(error_code ec,
                 }
                 d.fb.consume(d.fb.size());
                 d.ws.template write_close<
-                    static_buffer>(d.fb, code);
+                    flat_static_buffer_base>(d.fb, code);
                 if(d.ws.wr_block_)
                 {
                     // suspend
@@ -806,7 +806,7 @@ read_frame(DynamicBuffer& dynabuf, error_code& ec)
                 fb.consume(fb.size());
                 if(ctrl_cb_)
                     ctrl_cb_(frame_type::ping, payload);
-                write_ping<static_buffer>(fb,
+                write_ping<flat_static_buffer_base>(fb,
                     detail::opcode::pong, payload);
                 boost::asio::write(stream_, fb.data(), ec);
                 failed_ = !!ec;
@@ -839,7 +839,7 @@ read_frame(DynamicBuffer& dynabuf, error_code& ec)
                     cr.reason = "";
                     fb.consume(fb.size());
                     wr_close_ = true;
-                    write_close<static_buffer>(fb, cr);
+                    write_close<flat_static_buffer_base>(fb, cr);
                     boost::asio::write(stream_, fb.data(), ec);
                     failed_ = !!ec;
                     if(failed_)
@@ -966,7 +966,7 @@ do_close:
         {
             wr_close_ = true;
             detail::frame_streambuf fb;
-            write_close<static_buffer>(fb, code);
+            write_close<flat_static_buffer_base>(fb, code);
             boost::asio::write(stream_, fb.data(), ec);
             failed_ = !!ec;
             if(failed_)

--- a/include/beast/websocket/impl/read.ipp
+++ b/include/beast/websocket/impl/read.ipp
@@ -472,6 +472,8 @@ operator()(error_code ec,
                 }
                 BOOST_ASSERT(d.fh.op == detail::opcode::close);
                 {
+                    BOOST_ASSERT(! d.ws.rd_close_);
+                    d.ws.rd_close_ = true;
                     detail::read(d.ws.cr_, d.fb.data(), code);
                     if(code != close_code::none)
                     {
@@ -822,6 +824,8 @@ read_frame(DynamicBuffer& dynabuf, error_code& ec)
             }
             BOOST_ASSERT(fh.op == detail::opcode::close);
             {
+                BOOST_ASSERT(! rd_close_);
+                rd_close_ = true;
                 detail::read(cr_, fb.data(), code);
                 if(code != close_code::none)
                     goto do_close;

--- a/include/beast/websocket/impl/stream.ipp
+++ b/include/beast/websocket/impl/stream.ipp
@@ -501,10 +501,10 @@ build_request(detail::sec_ws_key_type& key,
 }
 
 template<class NextLayer>
-template<class Allocator, class Decorator>
+template<class Body, class Allocator, class Decorator>
 response_type
 stream<NextLayer>::
-build_response(http::header<true,
+build_response(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         Decorator const& decorator)
 {
@@ -598,10 +598,11 @@ do_accept(
 }
 
 template<class NextLayer>
-template<class Allocator, class Decorator>
+template<class Body, class Allocator,
+    class Decorator>
 void
 stream<NextLayer>::
-do_accept(http::header<true,
+do_accept(http::request<Body,
     http::basic_fields<Allocator>> const& req,
         Decorator const& decorator, error_code& ec)
 {
@@ -652,7 +653,7 @@ do_handshake(response_type* res_p,
 template<class NextLayer>
 void
 stream<NextLayer>::
-do_response(http::header<false> const& res,
+do_response(response_type const& res,
     detail::sec_ws_key_type const& key, error_code& ec)
 {
     bool const success = [&]()

--- a/include/beast/websocket/impl/stream.ipp
+++ b/include/beast/websocket/impl/stream.ipp
@@ -73,252 +73,6 @@ set_option(permessage_deflate const& o)
 template<class NextLayer>
 void
 stream<NextLayer>::
-reset()
-{
-    failed_ = false;
-    rd_.cont = false;
-    wr_close_ = false;
-    wr_.cont = false;
-    wr_block_ = nullptr;    // should be nullptr on close anyway
-    ping_data_ = nullptr;   // should be nullptr on close anyway
-
-    stream_.buffer().consume(
-        stream_.buffer().size());
-}
-
-template<class NextLayer>
-template<class Decorator>
-void
-stream<NextLayer>::
-do_accept(
-    Decorator const& decorator, error_code& ec)
-{
-    http::request_parser<http::empty_body> p;
-    http::read_header(next_layer(),
-        stream_.buffer(), p, ec);
-    if(ec)
-        return;
-    do_accept(p.get(), decorator, ec);
-}
-
-template<class NextLayer>
-template<class Allocator, class Decorator>
-void
-stream<NextLayer>::
-do_accept(http::header<true,
-    http::basic_fields<Allocator>> const& req,
-        Decorator const& decorator, error_code& ec)
-{
-    auto const res = build_response(req, decorator);
-    http::write(stream_, res, ec);
-    if(ec)
-        return;
-    if(res.result() != http::status::switching_protocols)
-    {
-        ec = error::handshake_failed;
-        // VFALCO TODO Respect keep alive setting, perform
-        //             teardown if Connection: close.
-        return;
-    }
-    pmd_read(pmd_config_, req);
-    open(role_type::server);
-}
-
-template<class NextLayer>
-template<class RequestDecorator>
-void
-stream<NextLayer>::
-do_handshake(response_type* res_p,
-    string_view host,
-        string_view target,
-            RequestDecorator const& decorator,
-                error_code& ec)
-{
-    response_type res;
-    reset();
-    detail::sec_ws_key_type key;
-    {
-        auto const req = build_request(
-            key, host, target, decorator);
-        pmd_read(pmd_config_, req);
-        http::write(stream_, req, ec);
-    }
-    if(ec)
-        return;
-    http::read(next_layer(), stream_.buffer(), res, ec);
-    if(ec)
-        return;
-    do_response(res, key, ec);
-    if(res_p)
-        *res_p = std::move(res);
-}
-
-template<class NextLayer>
-template<class Decorator>
-request_type
-stream<NextLayer>::
-build_request(detail::sec_ws_key_type& key,
-    string_view host,
-        string_view target,
-            Decorator const& decorator)
-{
-    request_type req;
-    req.target(target);
-    req.version = 11;
-    req.method(http::verb::get);
-    req.set(http::field::host, host);
-    req.set(http::field::upgrade, "websocket");
-    req.set(http::field::connection, "upgrade");
-    detail::make_sec_ws_key(key, maskgen_);
-    req.set(http::field::sec_websocket_key, key);
-    req.set(http::field::sec_websocket_version, "13");
-    if(pmd_opts_.client_enable)
-    {
-        detail::pmd_offer config;
-        config.accept = true;
-        config.server_max_window_bits =
-            pmd_opts_.server_max_window_bits;
-        config.client_max_window_bits =
-            pmd_opts_.client_max_window_bits;
-        config.server_no_context_takeover =
-            pmd_opts_.server_no_context_takeover;
-        config.client_no_context_takeover =
-            pmd_opts_.client_no_context_takeover;
-        detail::pmd_write(req, config);
-    }
-    decorator(req);
-    if(! req.count(http::field::user_agent))
-        req.set(http::field::user_agent,
-            BEAST_VERSION_STRING);
-    return req;
-}
-
-template<class NextLayer>
-template<class Allocator, class Decorator>
-response_type
-stream<NextLayer>::
-build_response(http::header<true,
-    http::basic_fields<Allocator>> const& req,
-        Decorator const& decorator)
-{
-    auto const decorate =
-        [&decorator](response_type& res)
-        {
-            decorator(res);
-            if(! res.count(http::field::server))
-            {
-                BOOST_STATIC_ASSERT(sizeof(BEAST_VERSION_STRING) < 20);
-                static_string<20> s(BEAST_VERSION_STRING);
-                res.set(http::field::server, s);
-            }
-        };
-    auto err =
-        [&](std::string const& text)
-        {
-            response_type res;
-            res.version = req.version;
-            res.result(http::status::bad_request);
-            res.body = text;
-            res.prepare_payload();
-            decorate(res);
-            return res;
-        };
-    if(req.version < 11)
-        return err("HTTP version 1.1 required");
-    if(req.method() != http::verb::get)
-        return err("Wrong method");
-    if(! is_upgrade(req))
-        return err("Expected Upgrade request");
-    if(! req.count(http::field::host))
-        return err("Missing Host");
-    if(! req.count(http::field::sec_websocket_key))
-        return err("Missing Sec-WebSocket-Key");
-    if(! http::token_list{req[http::field::upgrade]}.exists("websocket"))
-        return err("Missing websocket Upgrade token");
-    auto const key = req[http::field::sec_websocket_key];
-    if(key.size() > detail::sec_ws_key_type::max_size_n)
-        return err("Invalid Sec-WebSocket-Key");
-    {
-        auto const version =
-            req[http::field::sec_websocket_version];
-        if(version.empty())
-            return err("Missing Sec-WebSocket-Version");
-        if(version != "13")
-        {
-            response_type res;
-            res.result(http::status::upgrade_required);
-            res.version = req.version;
-            res.set(http::field::sec_websocket_version, "13");
-            res.prepare_payload();
-            decorate(res);
-            return res;
-        }
-    }
-
-    response_type res;
-    {
-        detail::pmd_offer offer;
-        detail::pmd_offer unused;
-        pmd_read(offer, req);
-        pmd_negotiate(res, unused, offer, pmd_opts_);
-    }
-    res.result(http::status::switching_protocols);
-    res.version = req.version;
-    res.set(http::field::upgrade, "websocket");
-    res.set(http::field::connection, "upgrade");
-    {
-        detail::sec_ws_accept_type acc;
-        detail::make_sec_ws_accept(acc, key);
-        res.set(http::field::sec_websocket_accept, acc);
-    }
-    decorate(res);
-    return res;
-}
-
-template<class NextLayer>
-void
-stream<NextLayer>::
-do_response(http::header<false> const& res,
-    detail::sec_ws_key_type const& key, error_code& ec)
-{
-    bool const success = [&]()
-    {
-        if(res.version < 11)
-            return false;
-        if(res.result() != http::status::switching_protocols)
-            return false;
-        if(! http::token_list{res[http::field::connection]}.exists("upgrade"))
-            return false;
-        if(! http::token_list{res[http::field::upgrade]}.exists("websocket"))
-            return false;
-        if(res.count(http::field::sec_websocket_accept) != 1)
-            return false;
-        detail::sec_ws_accept_type acc;
-        detail::make_sec_ws_accept(acc, key);
-        if(acc.compare(
-                res[http::field::sec_websocket_accept]) != 0)
-            return false;
-        return true;
-    }();
-    if(! success)
-    {
-        ec = error::handshake_failed;
-        return;
-    }
-    ec.assign(0, ec.category());
-    detail::pmd_offer offer;
-    pmd_read(offer, res);
-    // VFALCO see if offer satisfies pmd_config_,
-    //        return an error if not.
-    pmd_config_ = offer; // overwrite for now
-    open(role_type::client);
-}
-
-//------------------------------------------------------------------------------
-
-template<class NextLayer>
-void
-stream<NextLayer>::
 open(role_type role)
 {
     // VFALCO TODO analyze and remove dupe code in reset()
@@ -370,6 +124,69 @@ close()
     wr_.buf.reset();
     pmd_.reset();
 }
+
+template<class NextLayer>
+void
+stream<NextLayer>::
+reset()
+{
+    failed_ = false;
+    rd_.cont = false;
+    wr_close_ = false;
+    wr_.cont = false;
+    wr_block_ = nullptr;    // should be nullptr on close anyway
+    ping_data_ = nullptr;   // should be nullptr on close anyway
+
+    stream_.buffer().consume(
+        stream_.buffer().size());
+}
+
+// Called before each read frame
+template<class NextLayer>
+void
+stream<NextLayer>::
+rd_begin()
+{
+    // Maintain the read buffer
+    if(pmd_)
+    {
+        if(! rd_.buf || rd_.buf_size != rd_buf_size_)
+        {
+            rd_.buf_size = rd_buf_size_;
+            rd_.buf = boost::make_unique_noinit<
+                std::uint8_t[]>(rd_.buf_size);
+        }
+    }
+}
+
+// Called before each write frame
+template<class NextLayer>
+void
+stream<NextLayer>::
+wr_begin()
+{
+    wr_.autofrag = wr_autofrag_;
+    wr_.compress = static_cast<bool>(pmd_);
+
+    // Maintain the write buffer
+    if( wr_.compress ||
+        role_ == role_type::client)
+    {
+        if(! wr_.buf || wr_.buf_size != wr_buf_size_)
+        {
+            wr_.buf_size = wr_buf_size_;
+            wr_.buf = boost::make_unique_noinit<
+                std::uint8_t[]>(wr_.buf_size);
+        }
+    }
+    else
+    {
+        wr_.buf_size = wr_buf_size_;
+        wr_.buf.reset();
+    }
+}
+
+//------------------------------------------------------------------------------
 
 // Read fixed frame header from buffer
 // Requires at least 2 bytes
@@ -560,49 +377,6 @@ read_fh2(detail::frame_header& fh,
 }
 
 template<class NextLayer>
-void
-stream<NextLayer>::
-rd_begin()
-{
-    // Maintain the read buffer
-    if(pmd_)
-    {
-        if(! rd_.buf || rd_.buf_size != rd_buf_size_)
-        {
-            rd_.buf_size = rd_buf_size_;
-            rd_.buf = boost::make_unique_noinit<
-                std::uint8_t[]>(rd_.buf_size);
-        }
-    }
-}
-
-template<class NextLayer>
-void
-stream<NextLayer>::
-wr_begin()
-{
-    wr_.autofrag = wr_autofrag_;
-    wr_.compress = static_cast<bool>(pmd_);
-
-    // Maintain the write buffer
-    if( wr_.compress ||
-        role_ == role_type::client)
-    {
-        if(! wr_.buf || wr_.buf_size != wr_buf_size_)
-        {
-            wr_.buf_size = wr_buf_size_;
-            wr_.buf = boost::make_unique_noinit<
-                std::uint8_t[]>(wr_.buf_size);
-        }
-    }
-    else
-    {
-        wr_.buf_size = wr_buf_size_;
-        wr_.buf.reset();
-    }
-}
-
-template<class NextLayer>
 template<class DynamicBuffer>
 void
 stream<NextLayer>::
@@ -681,6 +455,238 @@ write_ping(DynamicBuffer& db,
         detail::mask_inplace(d, key);
     db.commit(data.size());
 }
+
+//------------------------------------------------------------------------------
+
+template<class NextLayer>
+template<class Decorator>
+request_type
+stream<NextLayer>::
+build_request(detail::sec_ws_key_type& key,
+    string_view host,
+        string_view target,
+            Decorator const& decorator)
+{
+    request_type req;
+    req.target(target);
+    req.version = 11;
+    req.method(http::verb::get);
+    req.set(http::field::host, host);
+    req.set(http::field::upgrade, "websocket");
+    req.set(http::field::connection, "upgrade");
+    detail::make_sec_ws_key(key, maskgen_);
+    req.set(http::field::sec_websocket_key, key);
+    req.set(http::field::sec_websocket_version, "13");
+    if(pmd_opts_.client_enable)
+    {
+        detail::pmd_offer config;
+        config.accept = true;
+        config.server_max_window_bits =
+            pmd_opts_.server_max_window_bits;
+        config.client_max_window_bits =
+            pmd_opts_.client_max_window_bits;
+        config.server_no_context_takeover =
+            pmd_opts_.server_no_context_takeover;
+        config.client_no_context_takeover =
+            pmd_opts_.client_no_context_takeover;
+        detail::pmd_write(req, config);
+    }
+    decorator(req);
+    if(! req.count(http::field::user_agent))
+        req.set(http::field::user_agent,
+            BEAST_VERSION_STRING);
+    return req;
+}
+
+template<class NextLayer>
+template<class Allocator, class Decorator>
+response_type
+stream<NextLayer>::
+build_response(http::header<true,
+    http::basic_fields<Allocator>> const& req,
+        Decorator const& decorator)
+{
+    auto const decorate =
+        [&decorator](response_type& res)
+        {
+            decorator(res);
+            if(! res.count(http::field::server))
+            {
+                BOOST_STATIC_ASSERT(sizeof(BEAST_VERSION_STRING) < 20);
+                static_string<20> s(BEAST_VERSION_STRING);
+                res.set(http::field::server, s);
+            }
+        };
+    auto err =
+        [&](std::string const& text)
+        {
+            response_type res;
+            res.version = req.version;
+            res.result(http::status::bad_request);
+            res.body = text;
+            res.prepare_payload();
+            decorate(res);
+            return res;
+        };
+    if(req.version < 11)
+        return err("HTTP version 1.1 required");
+    if(req.method() != http::verb::get)
+        return err("Wrong method");
+    if(! is_upgrade(req))
+        return err("Expected Upgrade request");
+    if(! req.count(http::field::host))
+        return err("Missing Host");
+    if(! req.count(http::field::sec_websocket_key))
+        return err("Missing Sec-WebSocket-Key");
+    if(! http::token_list{req[http::field::upgrade]}.exists("websocket"))
+        return err("Missing websocket Upgrade token");
+    auto const key = req[http::field::sec_websocket_key];
+    if(key.size() > detail::sec_ws_key_type::max_size_n)
+        return err("Invalid Sec-WebSocket-Key");
+    {
+        auto const version =
+            req[http::field::sec_websocket_version];
+        if(version.empty())
+            return err("Missing Sec-WebSocket-Version");
+        if(version != "13")
+        {
+            response_type res;
+            res.result(http::status::upgrade_required);
+            res.version = req.version;
+            res.set(http::field::sec_websocket_version, "13");
+            res.prepare_payload();
+            decorate(res);
+            return res;
+        }
+    }
+
+    response_type res;
+    {
+        detail::pmd_offer offer;
+        detail::pmd_offer unused;
+        pmd_read(offer, req);
+        pmd_negotiate(res, unused, offer, pmd_opts_);
+    }
+    res.result(http::status::switching_protocols);
+    res.version = req.version;
+    res.set(http::field::upgrade, "websocket");
+    res.set(http::field::connection, "upgrade");
+    {
+        detail::sec_ws_accept_type acc;
+        detail::make_sec_ws_accept(acc, key);
+        res.set(http::field::sec_websocket_accept, acc);
+    }
+    decorate(res);
+    return res;
+}
+
+template<class NextLayer>
+template<class Decorator>
+void
+stream<NextLayer>::
+do_accept(
+    Decorator const& decorator, error_code& ec)
+{
+    http::request_parser<http::empty_body> p;
+    http::read_header(next_layer(),
+        stream_.buffer(), p, ec);
+    if(ec)
+        return;
+    do_accept(p.get(), decorator, ec);
+}
+
+template<class NextLayer>
+template<class Allocator, class Decorator>
+void
+stream<NextLayer>::
+do_accept(http::header<true,
+    http::basic_fields<Allocator>> const& req,
+        Decorator const& decorator, error_code& ec)
+{
+    auto const res = build_response(req, decorator);
+    http::write(stream_, res, ec);
+    if(ec)
+        return;
+    if(res.result() != http::status::switching_protocols)
+    {
+        ec = error::handshake_failed;
+        // VFALCO TODO Respect keep alive setting, perform
+        //             teardown if Connection: close.
+        return;
+    }
+    pmd_read(pmd_config_, req);
+    open(role_type::server);
+}
+
+template<class NextLayer>
+template<class RequestDecorator>
+void
+stream<NextLayer>::
+do_handshake(response_type* res_p,
+    string_view host,
+        string_view target,
+            RequestDecorator const& decorator,
+                error_code& ec)
+{
+    response_type res;
+    reset();
+    detail::sec_ws_key_type key;
+    {
+        auto const req = build_request(
+            key, host, target, decorator);
+        pmd_read(pmd_config_, req);
+        http::write(stream_, req, ec);
+    }
+    if(ec)
+        return;
+    http::read(next_layer(), stream_.buffer(), res, ec);
+    if(ec)
+        return;
+    do_response(res, key, ec);
+    if(res_p)
+        *res_p = std::move(res);
+}
+
+template<class NextLayer>
+void
+stream<NextLayer>::
+do_response(http::header<false> const& res,
+    detail::sec_ws_key_type const& key, error_code& ec)
+{
+    bool const success = [&]()
+    {
+        if(res.version < 11)
+            return false;
+        if(res.result() != http::status::switching_protocols)
+            return false;
+        if(! http::token_list{res[http::field::connection]}.exists("upgrade"))
+            return false;
+        if(! http::token_list{res[http::field::upgrade]}.exists("websocket"))
+            return false;
+        if(res.count(http::field::sec_websocket_accept) != 1)
+            return false;
+        detail::sec_ws_accept_type acc;
+        detail::make_sec_ws_accept(acc, key);
+        if(acc.compare(
+                res[http::field::sec_websocket_accept]) != 0)
+            return false;
+        return true;
+    }();
+    if(! success)
+    {
+        ec = error::handshake_failed;
+        return;
+    }
+    ec.assign(0, ec.category());
+    detail::pmd_offer offer;
+    pmd_read(offer, res);
+    // VFALCO see if offer satisfies pmd_config_,
+    //        return an error if not.
+    pmd_config_ = offer; // overwrite for now
+    open(role_type::client);
+}
+
+//------------------------------------------------------------------------------
 
 } // websocket
 } // beast

--- a/include/beast/websocket/impl/stream.ipp
+++ b/include/beast/websocket/impl/stream.ipp
@@ -19,7 +19,7 @@
 #include <beast/core/buffer_cat.hpp>
 #include <beast/core/buffer_prefix.hpp>
 #include <beast/core/consuming_buffers.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/core/type_traits.hpp>
 #include <beast/core/detail/type_traits.hpp>
 #include <boost/assert.hpp>

--- a/include/beast/websocket/impl/stream.ipp
+++ b/include/beast/websocket/impl/stream.ipp
@@ -79,6 +79,7 @@ open(role_type role)
     role_ = role;
     failed_ = false;
     rd_.cont = false;
+    rd_close_ = false;
     wr_close_ = false;
     wr_block_ = nullptr;    // should be nullptr on close anyway
     ping_data_ = nullptr;   // should be nullptr on close anyway
@@ -132,6 +133,7 @@ reset()
 {
     failed_ = false;
     rd_.cont = false;
+    rd_close_ = false;
     wr_close_ = false;
     wr_.cont = false;
     wr_block_ = nullptr;    // should be nullptr on close anyway

--- a/include/beast/websocket/impl/write.ipp
+++ b/include/beast/websocket/impl/write.ipp
@@ -13,7 +13,7 @@
 #include <beast/core/buffer_prefix.hpp>
 #include <beast/core/consuming_buffers.hpp>
 #include <beast/core/handler_ptr.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/core/type_traits.hpp>
 #include <beast/core/detail/clamp.hpp>
 #include <beast/core/detail/config.hpp>
@@ -215,7 +215,7 @@ loop:
         BOOST_ASSERT(d.ws.wr_block_ == &d);
         d.fh.fin = d.fin;
         d.fh.len = buffer_size(d.cb);
-        detail::write<static_buffer>(
+        detail::write<flat_static_buffer_base>(
             d.fh_buf, d.fh);
         d.ws.wr_.cont = ! d.fin;
         // Send frame
@@ -235,7 +235,7 @@ loop:
         d.remain -= n;
         d.fh.len = n;
         d.fh.fin = d.fin ? d.remain == 0 : false;
-        detail::write<static_buffer>(
+        detail::write<flat_static_buffer_base>(
             d.fh_buf, d.fh);
         d.ws.wr_.cont = ! d.fin;
         // Send frame
@@ -277,7 +277,7 @@ loop:
         d.fh.len = d.remain;
         d.fh.key = d.ws.maskgen_();
         detail::prepare_key(d.key, d.fh.key);
-        detail::write<static_buffer>(
+        detail::write<flat_static_buffer_base>(
             d.fh_buf, d.fh);
         auto const n =
             clamp(d.remain, d.ws.wr_.buf_size);
@@ -329,7 +329,7 @@ loop:
             d.ws.wr_.buf.get(), n);
         buffer_copy(b, d.cb);
         detail::mask_inplace(b, d.key);
-        detail::write<static_buffer>(
+        detail::write<flat_static_buffer_base>(
             d.fh_buf, d.fh);
         d.ws.wr_.cont = ! d.fin;
         // Send frame
@@ -402,7 +402,7 @@ loop:
         d.fh.fin = ! more;
         d.fh.len = n;
         detail::fh_streambuf fh_buf;
-        detail::write<static_buffer>(fh_buf, d.fh);
+        detail::write<flat_static_buffer_base>(fh_buf, d.fh);
         d.ws.wr_.cont = ! d.fin;
         // Send frame
         d.step = more ?
@@ -699,7 +699,7 @@ write_frame(bool fin,
             fh.fin = ! more;
             fh.len = n;
             detail::fh_streambuf fh_buf;
-            detail::write<static_buffer>(fh_buf, fh);
+            detail::write<flat_static_buffer_base>(fh_buf, fh);
             wr_.cont = ! fin;
             boost::asio::write(stream_,
                 buffer_cat(fh_buf.data(), b), ec);
@@ -727,7 +727,7 @@ write_frame(bool fin,
             fh.fin = fin;
             fh.len = remain;
             detail::fh_streambuf fh_buf;
-            detail::write<static_buffer>(fh_buf, fh);
+            detail::write<flat_static_buffer_base>(fh_buf, fh);
             wr_.cont = ! fin;
             boost::asio::write(stream_,
                 buffer_cat(fh_buf.data(), buffers), ec);
@@ -748,7 +748,7 @@ write_frame(bool fin,
                 fh.len = n;
                 fh.fin = fin ? remain == 0 : false;
                 detail::fh_streambuf fh_buf;
-                detail::write<static_buffer>(fh_buf, fh);
+                detail::write<flat_static_buffer_base>(fh_buf, fh);
                 wr_.cont = ! fin;
                 boost::asio::write(stream_,
                     buffer_cat(fh_buf.data(),
@@ -773,7 +773,7 @@ write_frame(bool fin,
         detail::prepared_key key;
         detail::prepare_key(key, fh.key);
         detail::fh_streambuf fh_buf;
-        detail::write<static_buffer>(fh_buf, fh);
+        detail::write<flat_static_buffer_base>(fh_buf, fh);
         consuming_buffers<
             ConstBufferSequence> cb{buffers};
         {
@@ -824,7 +824,7 @@ write_frame(bool fin,
             fh.fin = fin ? remain == 0 : false;
             wr_.cont = ! fh.fin;
             detail::fh_streambuf fh_buf;
-            detail::write<static_buffer>(fh_buf, fh);
+            detail::write<flat_static_buffer_base>(fh_buf, fh);
             boost::asio::write(stream_,
                 buffer_cat(fh_buf.data(), b), ec);
             failed_ = !!ec;

--- a/include/beast/websocket/stream.hpp
+++ b/include/beast/websocket/stream.hpp
@@ -213,6 +213,7 @@ class stream
     role_type role_;                        // server or client
     bool failed_;                           // the connection failed
 
+    bool rd_close_;                         // read close frame
     bool wr_close_;                         // sent close frame
     op* wr_block_;                          // op currenly writing
 

--- a/include/beast/websocket/stream.hpp
+++ b/include/beast/websocket/stream.hpp
@@ -18,14 +18,15 @@
 #include <beast/websocket/detail/pausation.hpp>
 #include <beast/websocket/detail/pmd_extension.hpp>
 #include <beast/websocket/detail/utf8_checker.hpp>
+#include <beast/core/async_result.hpp>
+#include <beast/core/buffered_read_stream.hpp>
+#include <beast/core/flat_buffer.hpp>
+#include <beast/core/string.hpp>
+#include <beast/core/detail/type_traits.hpp>
 #include <beast/http/empty_body.hpp>
 #include <beast/http/message.hpp>
 #include <beast/http/string_body.hpp>
 #include <beast/http/detail/type_traits.hpp>
-#include <beast/core/async_result.hpp>
-#include <beast/core/buffered_read_stream.hpp>
-#include <beast/core/string.hpp>
-#include <beast/core/detail/type_traits.hpp>
 #include <beast/zlib/deflate_stream.hpp>
 #include <beast/zlib/inflate_stream.hpp>
 #include <boost/asio.hpp>
@@ -200,7 +201,7 @@ class stream
     };
 
     buffered_read_stream<
-        NextLayer, multi_buffer> stream_;   // the wrapped stream
+        NextLayer, flat_buffer> stream_;    // the wrapped stream
     detail::maskgen maskgen_;               // source of mask keys
     std::size_t rd_msg_max_ =
         16 * 1024 * 1024;                   // max message size

--- a/include/beast/websocket/stream.hpp
+++ b/include/beast/websocket/stream.hpp
@@ -999,9 +999,10 @@ public:
 
         @throws system_error Thrown on failure.
     */
-    template<class Allocator>
+    template<class Body, class Allocator>
     void
-    accept(http::header<true, http::basic_fields<Allocator>> const& req);
+    accept(http::request<Body,
+        http::basic_fields<Allocator>> const& req);
 
     /** Respond to a WebSocket HTTP Upgrade request
 
@@ -1040,9 +1041,10 @@ public:
 
         @throws system_error Thrown on failure.
     */
-    template<class Allocator, class ResponseDecorator>
+    template<class Body, class Allocator,
+        class ResponseDecorator>
     void
-    accept_ex(http::header<true,
+    accept_ex(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             ResponseDecorator const& decorator);
 
@@ -1074,10 +1076,11 @@ public:
 
         @param ec Set to indicate what error occurred, if any.
     */
-    template<class Allocator>
+    template<class Body, class Allocator>
     void
-    accept(http::header<true, http::basic_fields<Allocator>> const& req,
-        error_code& ec);
+    accept(http::request<Body,
+        http::basic_fields<Allocator>> const& req,
+            error_code& ec);
 
     /** Respond to a WebSocket HTTP Upgrade request
 
@@ -1116,9 +1119,10 @@ public:
 
         @param ec Set to indicate what error occurred, if any.
     */
-    template<class Allocator, class ResponseDecorator>
+    template<class Body, class Allocator,
+        class ResponseDecorator>
     void
-    accept_ex(http::header<true,
+    accept_ex(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             ResponseDecorator const& decorator,
                 error_code& ec);
@@ -1156,10 +1160,12 @@ public:
 
         @throws system_error Thrown on failure.
     */
-    template<class Allocator, class ConstBufferSequence>
+    template<class Body, class Allocator,
+        class ConstBufferSequence>
     void
-    accept(http::header<true, http::basic_fields<Allocator>> const& req,
-        ConstBufferSequence const& buffers);
+    accept(http::request<Body,
+        http::basic_fields<Allocator>> const& req,
+            ConstBufferSequence const& buffers);
 
     /** Respond to a WebSocket HTTP Upgrade request
 
@@ -1203,10 +1209,10 @@ public:
 
         @throws system_error Thrown on failure.
     */
-    template<class Allocator, class ConstBufferSequence,
-        class ResponseDecorator>
+    template<class Body, class Allocator,
+        class ConstBufferSequence, class ResponseDecorator>
     void
-    accept_ex(http::header<true,
+    accept_ex(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             ConstBufferSequence const& buffers,
                 ResponseDecorator const& decorator);
@@ -1244,10 +1250,13 @@ public:
 
         @param ec Set to indicate what error occurred, if any.
     */
-    template<class Allocator, class ConstBufferSequence>
+    template<class Body, class Allocator,
+        class ConstBufferSequence>
     void
-    accept(http::header<true, Allocator> const& req,
-        ConstBufferSequence const& buffers, error_code& ec);
+    accept(http::request<Body,
+        http::basic_fields<Allocator>> const& req,
+            ConstBufferSequence const& buffers,
+                error_code& ec);
 
     /** Respond to a WebSocket HTTP Upgrade request
 
@@ -1291,10 +1300,10 @@ public:
 
         @param ec Set to indicate what error occurred, if any.
     */
-    template<class Allocator, class ConstBufferSequence,
-        class ResponseDecorator>
+    template<class Body, class Allocator,
+        class ConstBufferSequence, class ResponseDecorator>
     void
-    accept_ex(http::header<true,
+    accept_ex(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             ConstBufferSequence const& buffers,
                 ResponseDecorator const& decorator,
@@ -1580,14 +1589,15 @@ public:
         this function. Invocation of the handler will be performed in a
         manner equivalent to using `boost::asio::io_service::post`.
     */
-    template<class Allocator, class AcceptHandler>
+    template<class Body, class Allocator,
+        class AcceptHandler>
 #if BEAST_DOXYGEN
     void_or_deduced
 #else
     async_return_type<
         AcceptHandler, void(error_code)>
 #endif
-    async_accept(http::header<true,
+    async_accept(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             AcceptHandler&& handler);
 
@@ -1645,7 +1655,7 @@ public:
         this function. Invocation of the handler will be performed in a
         manner equivalent to using `boost::asio::io_service::post`.
     */
-    template<class Allocator,
+    template<class Body, class Allocator,
         class ResponseDecorator, class AcceptHandler>
 #if BEAST_DOXYGEN
     void_or_deduced
@@ -1653,7 +1663,7 @@ public:
     async_return_type<
         AcceptHandler, void(error_code)>
 #endif
-    async_accept_ex(http::header<true,
+    async_accept_ex(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             ResponseDecorator const& decorator,
                 AcceptHandler&& handler);
@@ -1710,7 +1720,7 @@ public:
         this function. Invocation of the handler will be performed in a
         manner equivalent to using `boost::asio::io_service::post`.
     */
-    template<class Allocator,
+    template<class Body, class Allocator,
         class ConstBufferSequence, class AcceptHandler>
 #if BEAST_DOXYGEN
     void_or_deduced
@@ -1718,7 +1728,7 @@ public:
     async_return_type<
         AcceptHandler, void(error_code)>
 #endif
-    async_accept(http::header<true,
+    async_accept(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             ConstBufferSequence const& buffers,
                 AcceptHandler&& handler);
@@ -1784,19 +1794,23 @@ public:
         this function. Invocation of the handler will be performed in a
         manner equivalent to using `boost::asio::io_service::post`.
     */
-    template<class Allocator, class ConstBufferSequence,
-        class ResponseDecorator, class AcceptHandler>
+    template<
+        class Body, class Allocator,
+        class ConstBufferSequence,
+        class ResponseDecorator,
+        class AcceptHandler>
 #if BEAST_DOXYGEN
     void_or_deduced
 #else
     async_return_type<
         AcceptHandler, void(error_code)>
 #endif
-    async_accept_ex(http::header<true,
-        http::basic_fields<Allocator>> const& req,
-            ConstBufferSequence const& buffers,
-                ResponseDecorator const& decorator,
-                    AcceptHandler&& handler);
+    async_accept_ex(
+        http::request<Body,
+            http::basic_fields<Allocator>> const& req,
+        ConstBufferSequence const& buffers,
+        ResponseDecorator const& decorator,
+        AcceptHandler&& handler);
 
     /** Send an HTTP WebSocket Upgrade request and receive the response.
 
@@ -3326,9 +3340,10 @@ private:
             string_view target,
                 Decorator const& decorator);
 
-    template<class Allocator, class Decorator>
+    template<class Body,
+        class Allocator, class Decorator>
     response_type
-    build_response(http::header<true,
+    build_response(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             Decorator const& decorator);
 
@@ -3337,22 +3352,22 @@ private:
     do_accept(Decorator const& decorator,
         error_code& ec);
 
-    template<class Allocator, class Decorator>
+    template<class Body, class Allocator,
+        class Decorator>
     void
-    do_accept(http::header<true,
+    do_accept(http::request<Body,
         http::basic_fields<Allocator>> const& req,
             Decorator const& decorator, error_code& ec);
 
     template<class RequestDecorator>
     void
     do_handshake(response_type* res_p,
-        string_view host,
-            string_view target,
-                RequestDecorator const& decorator,
-                    error_code& ec);
+        string_view host, string_view target,
+            RequestDecorator const& decorator,
+                error_code& ec);
 
     void
-    do_response(http::header<false> const& resp,
+    do_response(response_type const& resp,
         detail::sec_ws_key_type const& key, error_code& ec);
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_subdirectory (core)
 add_subdirectory (http)
 add_subdirectory (websocket)
+add_subdirectory (wstest)
 add_subdirectory (zlib)
 
 if ((NOT "${VARIANT}" STREQUAL "coverage") AND

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -34,4 +34,5 @@ build-project core ;
 build-project http ;
 build-project server ;
 build-project websocket ;
+build-project wstest ;
 build-project zlib ;

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable (common-test
     detect_ssl.cpp
     mime_types.cpp
     rfc7231.cpp
+    session_alloc.cpp
     ssl_stream.cpp
     write_msg.cpp
     main.cpp

--- a/test/common/Jamfile
+++ b/test/common/Jamfile
@@ -9,6 +9,7 @@ exe common-test :
     detect_ssl.cpp
     mime_types.cpp
     rfc7231.cpp
+    session_alloc.cpp
     ssl_stream.cpp
     write_msg.cpp
     main.cpp

--- a/test/common/session_alloc.cpp
+++ b/test/common/session_alloc.cpp
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// Test that header file is self-contained.
+#include "example/common/session_alloc.hpp"
+

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -30,13 +30,13 @@ add_executable (core-tests
     file_stdio.cpp
     file_win32.cpp
     flat_buffer.cpp
+    flat_static_buffer.cpp
     handler_alloc.cpp
     handler_ptr.cpp
     multi_buffer.cpp
     ostream.cpp
     read_size.cpp
     span.cpp
-    static_buffer.cpp
     static_string.cpp
     string.cpp
     string_param.cpp

--- a/test/core/Jamfile
+++ b/test/core/Jamfile
@@ -24,13 +24,13 @@ unit-test core-tests :
     file_stdio.cpp
     file_win32.cpp
     flat_buffer.cpp
+    flat_static_buffer.cpp
     handler_alloc.cpp
     handler_ptr.cpp
     multi_buffer.cpp
     ostream.cpp
     read_size.cpp
     span.cpp
-    static_buffer.cpp
     static_string.cpp
     string.cpp
     string_param.cpp

--- a/test/core/flat_static_buffer.cpp
+++ b/test/core/flat_static_buffer.cpp
@@ -6,7 +6,7 @@
 //
 
 // Test that header file is self-contained.
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 
 #include "buffer_test.hpp"
 
@@ -18,10 +18,10 @@
 namespace beast {
 
 static_assert(
-    is_dynamic_buffer<static_buffer>::value,
+    is_dynamic_buffer<flat_static_buffer_base>::value,
     "DynamicBuffer requirements not met");
 
-class static_buffer_test : public beast::unit_test::suite
+class flat_static_buffer_test : public beast::unit_test::suite
 {
 public:
     void
@@ -44,7 +44,7 @@ public:
         std::size_t v = sizeof(buf) - (t + u);
         {
             std::memset(buf, 0, sizeof(buf));
-            static_buffer_n<sizeof(buf)> ba;
+            flat_static_buffer<sizeof(buf)> ba;
             {
                 auto d = ba.prepare(z);
                 BEAST_EXPECT(buffer_size(d) == z);
@@ -139,32 +139,32 @@ public:
         using namespace test;
         string_view const s = "Hello, world!";
         
-        // static_buffer
+        // flat_static_buffer_base
         {
             char buf[64];
-            static_buffer b{buf, sizeof(buf)};
+            flat_static_buffer_base b{buf, sizeof(buf)};
             ostream(b) << s;
             BEAST_EXPECT(to_string(b.data()) == s);
             b.consume(b.size());
             BEAST_EXPECT(to_string(b.data()) == "");
         }
 
-        // static_buffer_n
+        // flat_static_buffer
         {
-            static_buffer_n<64> b1;
+            flat_static_buffer<64> b1;
             BEAST_EXPECT(b1.size() == 0);
             BEAST_EXPECT(b1.max_size() == 64);
             BEAST_EXPECT(b1.capacity() == 64);
             ostream(b1) << s;
             BEAST_EXPECT(to_string(b1.data()) == s);
             {
-                static_buffer_n<64> b2{b1};
+                flat_static_buffer<64> b2{b1};
                 BEAST_EXPECT(to_string(b2.data()) == s);
                 b2.consume(7);
                 BEAST_EXPECT(to_string(b2.data()) == s.substr(7));
             }
             {
-                static_buffer_n<64> b2;
+                flat_static_buffer<64> b2;
                 b2 = b1;
                 BEAST_EXPECT(to_string(b2.data()) == s);
                 b2.consume(7);
@@ -174,7 +174,7 @@ public:
 
         // cause memmove
         {
-            static_buffer_n<10> b;
+            flat_static_buffer<10> b;
             write_buffer(b, "12345");
             b.consume(3);
             write_buffer(b, "67890123");
@@ -192,7 +192,7 @@ public:
 
         // read_size
         {
-            static_buffer_n<10> b;
+            flat_static_buffer<10> b;
             BEAST_EXPECT(read_size(b, 512) == 10);
             b.prepare(4);
             b.commit(4);
@@ -206,14 +206,14 @@ public:
 
         // base
         {
-            static_buffer_n<10> b;
-            [&](static_buffer& base)
+            flat_static_buffer<10> b;
+            [&](flat_static_buffer_base& base)
             {
                 BEAST_EXPECT(base.max_size() == b.capacity());
             }
             (b.base());
 
-            [&](static_buffer const& base)
+            [&](flat_static_buffer_base const& base)
             {
                 BEAST_EXPECT(base.max_size() == b.capacity());
             }
@@ -228,6 +228,6 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(static_buffer,core,beast);
+BEAST_DEFINE_TESTSUITE(flat_static_buffer,core,beast);
 
 } // beastp

--- a/test/core/type_traits.cpp
+++ b/test/core/type_traits.cpp
@@ -11,6 +11,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/streambuf.hpp>
 #include <boost/asio/detail/consuming_buffers.hpp>
+#include <memory>
 
 namespace beast {
 
@@ -37,6 +38,11 @@ struct is_invocable_udt3
     int operator()(int);
 };
 
+struct is_invocable_udt4
+{
+    void operator()(std::unique_ptr<int>);
+};
+
 #ifndef __INTELLISENSE__
 // VFALCO Fails to compile with Intellisense
 BOOST_STATIC_ASSERT(is_invocable<is_invocable_udt1, void(int)>::value);
@@ -46,6 +52,7 @@ BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt1, void(void)>::value);
 BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt2, int(void)>::value);
 BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt2, void(void)>::value);
 BOOST_STATIC_ASSERT(! is_invocable<is_invocable_udt3 const, int(int)>::value);
+BOOST_STATIC_ASSERT(is_invocable<is_invocable_udt4, void(std::unique_ptr<int>)>::value);
 #endif
 
 //

--- a/test/http/read.cpp
+++ b/test/http/read.cpp
@@ -11,7 +11,7 @@
 #include "test_parser.hpp"
 
 #include <beast/core/ostream.hpp>
-#include <beast/core/static_buffer.hpp>
+#include <beast/core/flat_static_buffer.hpp>
 #include <beast/http/fields.hpp>
 #include <beast/http/dynamic_body.hpp>
 #include <beast/http/parser.hpp>
@@ -135,7 +135,7 @@ public:
                 "10\r\n"
                 "****************\r\n"
                 "0\r\n\r\n";
-            static_buffer_n<1024> b;
+            flat_static_buffer<1024> b;
             request<string_body> req;
             try
             {
@@ -159,7 +159,7 @@ public:
                 "****************\r\n"
                 "0\r\n\r\n";
             error_code ec = test::error::fail_error;
-            static_buffer_n<10> b;
+            flat_static_buffer<10> b;
             request<string_body> req;
             read(p.server, b, req, ec);
             BEAST_EXPECTS(ec == error::buffer_overflow,

--- a/test/websocket/stream.cpp
+++ b/test/websocket/stream.cpp
@@ -138,19 +138,18 @@ public:
             ws.accept(buffers);
         }
 
-        template<class NextLayer, class Fields>
+        template<class NextLayer>
         void
         accept(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req) const
+            http::request<http::empty_body> const& req) const
         {
             ws.accept(req);
         }
 
-        template<class NextLayer,
-            class Fields, class Buffers>
+        template<class NextLayer, class Buffers>
         void
         accept(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req,
+            http::request<http::empty_body> const& req,
                 Buffers const& buffers) const
         {
             ws.accept(req, buffers);
@@ -175,22 +174,20 @@ public:
             ws.accept_ex(buffers, d);
         }
 
-        template<class NextLayer,
-            class Fields, class Decorator>
+        template<class NextLayer, class Decorator>
         void
         accept_ex(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req,
+            http::request<http::empty_body> const& req,
                 Decorator const& d) const
         {
             ws.accept_ex(req, d);
         }
 
         template<class NextLayer,
-            class Fields, class Buffers,
-                class Decorator>
+            class Buffers, class Decorator>
         void
         accept_ex(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req,
+            http::request<http::empty_body> const& req,
                 Buffers const& buffers,
                     Decorator const& d) const
         {
@@ -332,10 +329,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer, class Fields>
+        template<class NextLayer>
         void
         accept(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req) const
+            http::request<http::empty_body> const& req) const
         {
             error_code ec;
             ws.async_accept(req, yield_[ec]);
@@ -343,11 +340,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer,
-            class Fields, class Buffers>
+        template<class NextLayer, class Buffers>
         void
         accept(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req,
+            http::request<http::empty_body> const& req,
                 Buffers const& buffers) const
         {
             error_code ec;
@@ -382,11 +378,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer,
-            class Fields, class Decorator>
+        template<class NextLayer, class Decorator>
         void
         accept_ex(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req,
+            http::request<http::empty_body> const& req,
                 Decorator const& d) const
         {
             error_code ec;
@@ -395,11 +390,11 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer, class Fields,
+        template<class NextLayer,
             class Buffers, class Decorator>
         void
         accept_ex(stream<NextLayer>& ws,
-            http::header<true, Fields> const& req,
+            http::request<http::empty_body> const& req,
                 Buffers const& buffers,
                     Decorator const& d) const
         {

--- a/test/wstest/CMakeLists.txt
+++ b/test/wstest/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Part of Beast
+
+GroupSources(include/beast beast)
+GroupSources(example/common common)
+GroupSources(extras/beast extras)
+GroupSources(test/wstest "/")
+
+add_executable (wstest
+    ${BEAST_INCLUDES}
+    ${COMMON_INCLUDES}
+    ${EXTRAS_INCLUDES}
+    main.cpp
+    )
+
+target_link_libraries(wstest
+    Beast
+    )

--- a/test/wstest/Jamfile
+++ b/test/wstest/Jamfile
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+exe wstest :
+    main.cpp
+    ;

--- a/test/wstest/main.cpp
+++ b/test/wstest/main.cpp
@@ -1,0 +1,327 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <example/common/helpers.hpp>
+#include <example/common/session_alloc.hpp>
+
+#include <beast/core.hpp>
+#include <beast/websocket.hpp>
+#include <beast/unit_test/dstream.hpp>
+#include <boost/asio.hpp>
+#include <boost/lexical_cast.hpp>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <random>
+
+namespace asio = boost::asio;
+namespace ip = boost::asio::ip;
+using tcp = boost::asio::ip::tcp;
+namespace ws = beast::websocket;
+namespace ph = std::placeholders;
+using error_code = beast::error_code;
+
+class test_buffer : public asio::const_buffers_1
+{
+    char data_[4096];
+
+public:
+    test_buffer()
+        : asio::const_buffers_1(data_, sizeof(data_))
+    {
+        std::mt19937_64 rng;
+        std::uniform_int_distribution<unsigned short> dist;
+        for(auto& c : data_)
+            c = static_cast<unsigned char>(dist(rng));
+    }
+};
+
+class report
+{
+    std::mutex m_;
+    std::size_t bytes_ = 0;
+    std::size_t messages_ = 0;
+
+public:
+    void
+    insert(std::size_t messages, std::size_t bytes)
+    {
+        std::lock_guard<std::mutex> lock(m_);
+        bytes_ += bytes;
+        messages_ += messages;
+    }
+
+    std::size_t
+    bytes() const
+    {
+        return bytes_;
+    }
+
+    std::size_t
+    messages() const
+    {
+        return messages_;
+    }
+};
+
+class connection
+    : public std::enable_shared_from_this<connection>
+{
+    std::ostream& log_;
+    ws::stream<tcp::socket> ws_;
+    tcp::endpoint ep_;
+    std::size_t messages_;
+    report& rep_;
+    test_buffer const& tb_;
+    asio::io_service::strand strand_;
+    beast::multi_buffer buffer_;
+    std::mt19937_64 rng_;
+    std::size_t count_ = 0;
+    std::size_t bytes_ = 0;
+    session_alloc<char> alloc_;
+
+public:
+    connection(
+        std::ostream& log,
+        asio::io_service& ios,
+        tcp::endpoint const& ep,
+        std::size_t messages,
+        report& rep,
+        test_buffer const& tb)
+        : log_(log)
+        , ws_(ios)
+        , ep_(ep)
+        , messages_(messages)
+        , rep_(rep)
+        , tb_(tb)
+        , strand_(ios)
+    {
+        ws::permessage_deflate pmd;
+        pmd.client_enable = false;
+        ws_.set_option(pmd);
+        ws_.binary(true);
+    }
+
+    ~connection()
+    {
+        rep_.insert(count_, bytes_);
+    }
+
+    void
+    run()
+    {
+        ws_.next_layer().async_connect(ep_,
+            alloc_.wrap(std::bind(
+                &connection::on_connect,
+                shared_from_this(),
+                ph::_1)));
+    }
+
+private:
+    void
+    fail(beast::string_view what, error_code ec)
+    {
+        if( ec == asio::error::operation_aborted ||
+            ec == ws::error::closed)
+            return;
+        print(log_, "[", ep_, "] ", what, ": ", ec.message());
+    }
+
+    void
+    on_connect(error_code ec)
+    {
+        if(ec)
+            return fail("on_connect", ec);
+        ws_.async_handshake(
+            boost::lexical_cast<std::string>(ep_),
+            "/",
+            alloc_.wrap(std::bind(
+                &connection::on_handshake,
+                shared_from_this(),
+                ph::_1)));
+    }
+
+    void
+    on_handshake(error_code ec)
+    {
+        if(ec)
+            return fail("on_connect", ec);
+        do_write();
+    }
+
+    void
+    do_write()
+    {
+        std::geometric_distribution<std::size_t> dist{
+            double(4) / boost::asio::buffer_size(tb_)};
+        ws_.async_write_frame(true,
+            beast::buffer_prefix(dist(rng_), tb_),
+            alloc_.wrap(std::bind(
+                &connection::on_write,
+                shared_from_this(),
+                ph::_1)));
+    }
+
+    void
+    on_write(error_code ec)
+    {
+        if(ec)
+            return fail("on_read", ec);
+        if(messages_--)
+            return do_read();
+        ws_.async_close({},
+            alloc_.wrap(std::bind(
+                &connection::on_close,
+                shared_from_this(),
+                ph::_1)));
+    }
+
+    void
+    do_read()
+    {
+        ws_.async_read(buffer_,
+            alloc_.wrap(std::bind(
+                &connection::on_read,
+                shared_from_this(),
+                ph::_1)));
+    }
+
+    void
+    on_read(error_code ec)
+    {
+        if(ec)
+            return fail("on_read", ec);
+        ++count_;
+        bytes_ += buffer_.size();
+        buffer_.consume(buffer_.size());
+        do_write();
+    }
+
+    void
+    on_close(error_code ec)
+    {
+        if(ec)
+            return fail("on_close", ec);
+        do_drain();
+    }
+
+    void
+    do_drain()
+    {
+        ws_.async_read(buffer_,
+            alloc_.wrap(std::bind(
+                &connection::on_drain,
+                shared_from_this(),
+                ph::_1)));
+    }
+
+    void
+    on_drain(error_code ec)
+    {
+        if(ec)
+            return fail("on_drain", ec);
+        do_drain();
+    }
+
+};
+
+class timer
+{
+    using clock_type =
+        std::chrono::system_clock;
+
+    clock_type::time_point when_;
+
+public:
+    using duration =
+        clock_type::duration;
+
+    timer()
+        : when_(clock_type::now())
+    {
+    }
+
+    duration
+    elapsed() const
+    {
+        return clock_type::now() - when_;
+    }
+};
+
+inline
+std::uint64_t
+throughput(
+    std::chrono::duration<double> const& elapsed,
+    std::uint64_t items)
+{
+    using namespace std::chrono;
+    return static_cast<std::uint64_t>(
+        1 / (elapsed/items).count());
+}
+
+int
+main(int argc, char** argv)
+{
+    beast::unit_test::dstream dout(std::cerr);
+
+    try
+    {
+        // Check command line arguments.
+        if(argc != 6)
+        {
+            std::cerr <<
+                "Usage: " << argv[0] <<
+                " <address> <port> <trials> <messages> <workers>";
+            return EXIT_FAILURE;
+        }
+
+        auto const address = ip::address::from_string(argv[1]);
+        auto const port    = static_cast<unsigned short>(std::atoi(argv[2]));
+        auto const trials  = static_cast<std::size_t>(std::atoi(argv[3]));
+        auto const messages= static_cast<std::size_t>(std::atoi(argv[4]));
+        auto const workers = static_cast<std::size_t>(std::atoi(argv[5]));
+        auto const work = (messages + workers - 1) / workers;
+        test_buffer tb;
+        for(auto i = trials; i; --i)
+        {
+            report rep;
+            boost::asio::io_service ios{1};
+            for(auto j = workers; j; --j)
+            {
+                auto sp =
+                std::make_shared<connection>(
+                    dout,
+                    ios,
+                    tcp::endpoint{address, port},
+                    work,
+                    rep,
+                    tb);
+                sp->run();
+            }
+            timer t;
+            ios.run();
+            auto const elapsed = t.elapsed();
+            dout <<
+                throughput(elapsed, rep.bytes()) << " bytes/s in " <<
+                (std::chrono::duration_cast<
+                    std::chrono::milliseconds>(
+                    elapsed).count() / 1000.) << "ms and " <<
+                rep.bytes() << " bytes" << std::endl;
+        }
+    }
+    catch(std::exception const& e)
+    {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
* Documentation tidying
* is_invocable works with move-only types
* Use std::function and reference wrapper
* Add session_alloc to example/common

WebSocket

* stream tidying
* Add rd_close_ to websocket stream state
* stream uses flat_buffer
* accept requires a message
* Add wstest benchmark tool

API Changes:

* Rename to flat_static_buffer and flat_static_buffer_base

Actions Required:

* Rename static_buffer to flat_static_buffer_base
* Rename static_buffer_n to flat_static_buffer

Documentation preview:
http://vinniefalco.github.io/stage/beast/v82