### PR TITLE
fixed build error (src/test/benchmarks/utf8_checker.cpp:99:21: error: 'clock_type' is a private member of 'beast::utf8_checker_test::timer')

### DIFF
--- a/test/benchmarks/utf8_checker.cpp
+++ b/test/benchmarks/utf8_checker.cpp
@@ -22,9 +22,11 @@ public:
 
     class timer
     {
+    public:
         using clock_type =
             std::chrono::system_clock;
 
+    private:
         clock_type::time_point when_;
 
     public:


### PR DESCRIPTION
When I tried to build the project (clang 4.0.1), this compilation error occurred.