### PR TITLE
Version 84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 84:
+
+* Tidy up buffer_front
+
+--------------------------------------------------------------------------------
+
 Version 83:
 
 * Add flat_static_buffer::mutable_data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 84:
 
 * Tidy up buffer_front
+* static_buffer::consume improvement
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 84:
 * static_buffer::consume improvement
 * multi_buffer is type-check friendly
 * bind_handler allows placeholders
+* Add consuming_buffers::get
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 84:
 
 * Tidy up buffer_front
 * static_buffer::consume improvement
+* multi_buffer is type-check friendly
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 84:
 * Tidy up buffer_front
 * static_buffer::consume improvement
 * multi_buffer is type-check friendly
+* bind_handler allows placeholders
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Version 84:
 * bind_handler allows placeholders
 * Add consuming_buffers::get
 
+WebSocket:
+
+* WebSocket read optimization
+
+API Changes:
+
+* websocket::stream::read_buffer_size is removed
+
+Actions Required:
+
+* Remove calls websocket::stream::read_buffer_size
+* Use read_some and write_some instead of read_frame and write_frame
+
 --------------------------------------------------------------------------------
 
 Version 83:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 83)
+project (Beast VERSION 84)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/08_design/3_websocket_zaphoyd.qbk
+++ b/doc/qbk/08_design/3_websocket_zaphoyd.qbk
@@ -328,7 +328,7 @@ without bringing it all into memory.
         [```
             template<class ConstBufferSequence>
             void
-            write_frame(bool fin,
+            write_some(bool fin,
                 ConstBufferSequence const& buffers);
         ```]
         [

--- a/example/server-framework/main.cpp
+++ b/example/server-framework/main.cpp
@@ -22,6 +22,7 @@
 #include "file_service.hpp"
 #include "ws_upgrade_service.hpp"
 
+#include <boost/asio/signal_set.hpp>
 #include <boost/program_options.hpp>
 
 #include <iostream>

--- a/example/websocket-server-async/CMakeLists.txt
+++ b/example/websocket-server-async/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Part of Beast
 
 GroupSources(include/beast beast)
+GroupSources(example/common common)
 GroupSources(example/websocket-server-async "/")
 
 add_executable (websocket-server-async
     ${BEAST_INCLUDES}
+    ${COMMON_INCLUDES}
     websocket_server_async.cpp
 )
 

--- a/include/beast/core/bind_handler.hpp
+++ b/include/beast/core/bind_handler.hpp
@@ -18,11 +18,14 @@ namespace beast {
 
 /** Bind parameters to a completion handler, creating a new handler.
 
-    This function creates a new handler which, when invoked with no
-    parameters, calls the original handler with the list of bound
-    arguments. The passed handler and arguments are forwarded into
-    the returned handler, which provides the same `io_service`
-    execution guarantees as the original handler.
+    This function creates a new handler which, when invoked, calls
+    the original handler with the list of bound arguments. Any
+    parameters passed in the invocation will be subtituted for
+    placeholders present in the list of bound arguments. Parameters
+    which are not matched to placeholders are silently discarded.
+    The passed handler and arguments are forwarded into the returned
+    handler, which provides the same `io_service` execution guarantees
+    as the original handler.
 
     Unlike `boost::asio::io_service::wrap`, the returned handler can
     be used in a subsequent call to `boost::asio::io_service::post`
@@ -57,9 +60,11 @@ detail::bound_handler<
 #endif
 bind_handler(Handler&& handler, Args&&... args)
 {
+#if 0
     static_assert(is_completion_handler<
         Handler, void(Args...)>::value,
             "Handler requirements not met");
+#endif
     return detail::bound_handler<typename std::decay<
         Handler>::type, Args...>(std::forward<
             Handler>(handler), std::forward<Args>(args)...);

--- a/include/beast/core/buffer_prefix.hpp
+++ b/include/beast/core/buffer_prefix.hpp
@@ -225,7 +225,7 @@ buffer_front(BufferSequence const& buffers)
 {
     auto const first = buffers.begin();
     if(first == buffers.end())
-        return {nullptr, 0};
+        return {};
     return *first;
 }
 

--- a/include/beast/core/consuming_buffers.hpp
+++ b/include/beast/core/consuming_buffers.hpp
@@ -112,8 +112,15 @@ public:
     /// Assignment
     consuming_buffers& operator=(consuming_buffers&&);
 
-    /// Assignmen
+    /// Assignment
     consuming_buffers& operator=(consuming_buffers const&);
+
+    /// Returns the underlying buffers, without modification
+    BufferSequence const&
+    get() const
+    {
+        return bs_;
+    }
 
     /// Get a bidirectional iterator to the first element.
     const_iterator

--- a/include/beast/core/detail/clamp.hpp
+++ b/include/beast/core/detail/clamp.hpp
@@ -8,8 +8,9 @@
 #ifndef BEAST_CORE_DETAIL_CLAMP_HPP
 #define BEAST_CORE_DETAIL_CLAMP_HPP
 
-#include <limits>
 #include <cstdlib>
+#include <limits>
+#include <type_traits>
 
 namespace beast {
 namespace detail {
@@ -32,6 +33,20 @@ clamp(UInt x, std::size_t limit)
     if(x >= limit)
         return limit;
     return static_cast<std::size_t>(x);
+}
+
+// return `true` if x + y > z, which are unsigned
+template<
+    class U1, class U2, class U3>
+constexpr
+bool
+sum_exceeds(U1 x, U2 y, U3 z)
+{
+    static_assert(
+        std::is_unsigned<U1>::value &&
+        std::is_unsigned<U2>::value &&
+        std::is_unsigned<U3>::value, "");
+    return y > z || x > z - y;
 }
 
 } // detail

--- a/include/beast/core/impl/static_buffer.ipp
+++ b/include/beast/core/impl/static_buffer.ipp
@@ -260,9 +260,19 @@ void
 static_buffer_base::
 consume(std::size_t size)
 {
-    size = (std::min)(size, in_size_);
-    in_off_ = (in_off_ + size) % capacity_;
-    in_size_ -= size;
+    if(size < in_size_)
+    {
+        in_off_ = (in_off_ + size) % capacity_;
+        in_size_ -= size;
+    }
+    else
+    {
+        // rewind the offset, so the next call to prepare
+        // can have a longer continguous segment. this helps
+        // algorithms optimized for larger buffesr.
+        in_off_ = 0;
+        in_size_ = 0;
+    }
 }
 
 inline

--- a/include/beast/core/multi_buffer.hpp
+++ b/include/beast/core/multi_buffer.hpp
@@ -9,7 +9,6 @@
 #define BEAST_MULTI_BUFFER_HPP
 
 #include <beast/config.hpp>
-#include <beast/core/detail/empty_base_optimization.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/intrusive/list.hpp>
 #include <iterator>
@@ -32,11 +31,6 @@ namespace beast {
 */
 template<class Allocator>
 class basic_multi_buffer
-#if ! BEAST_DOXYGEN
-    : private detail::empty_base_optimization<
-        typename std::allocator_traits<Allocator>::
-            template rebind_alloc<char>>
-#endif
 {
 public:
 #if BEAST_DOXYGEN
@@ -57,29 +51,30 @@ private:
     using alloc_traits = std::allocator_traits<allocator_type>;
     using list_type = typename boost::intrusive::make_list<element,
         boost::intrusive::constant_time_size<true>>::type;
-    using iterator = typename list_type::iterator;
-    using const_iterator = typename list_type::const_iterator;
+    using iter = typename list_type::iterator;
+    using const_iter = typename list_type::const_iterator;
 
     using size_type = typename std::allocator_traits<Allocator>::size_type;
     using const_buffer = boost::asio::const_buffer;
     using mutable_buffer = boost::asio::mutable_buffer;
 
     static_assert(std::is_base_of<std::bidirectional_iterator_tag,
-        typename std::iterator_traits<iterator>::iterator_category>::value,
+        typename std::iterator_traits<iter>::iterator_category>::value,
             "BidirectionalIterator requirements not met");
 
     static_assert(std::is_base_of<std::bidirectional_iterator_tag,
-        typename std::iterator_traits<const_iterator>::iterator_category>::value,
+        typename std::iterator_traits<const_iter>::iterator_category>::value,
             "BidirectionalIterator requirements not met");
 
     std::size_t max_ =
         (std::numeric_limits<std::size_t>::max)();
     list_type list_;        // list of allocated buffers
-    iterator out_;          // element that contains out_pos_
+    iter out_;              // element that contains out_pos_
     size_type in_size_ = 0; // size of the input sequence
     size_type in_pos_ = 0;  // input offset in list_.front()
     size_type out_pos_ = 0; // output offset in *out_
     size_type out_end_ = 0; // output end offset in list_.back()
+    allocator_type alloc_;  // the allocator
 
 public:
 #if BEAST_DOXYGEN
@@ -217,7 +212,7 @@ public:
     allocator_type
     get_allocator() const
     {
-        return this->member();
+        return alloc_;
     }
 
     /// Returns the size of the input sequence.

--- a/include/beast/version.hpp
+++ b/include/beast/version.hpp
@@ -18,7 +18,7 @@
     This is a simple integer that is incremented by one every time
     a set of code changes is merged to the master or develop branch.
 */
-#define BEAST_VERSION 83
+#define BEAST_VERSION 84
 
 #define BEAST_VERSION_STRING "Beast/" BOOST_STRINGIZE(BEAST_VERSION)
 

--- a/include/beast/websocket/detail/frame.hpp
+++ b/include/beast/websocket/detail/frame.hpp
@@ -96,14 +96,14 @@ enum class opcode : std::uint8_t
 // Contents of a WebSocket frame header
 struct frame_header
 {
-    opcode op;
-    bool fin;
-    bool mask;
-    bool rsv1;
-    bool rsv2;
-    bool rsv3;
     std::uint64_t len;
     std::uint32_t key;
+    opcode op;
+    bool fin  : 1;
+    bool mask : 1;
+    bool rsv1 : 1;
+    bool rsv2 : 1;
+    bool rsv3 : 1;
 };
 
 // holds the largest possible frame header
@@ -226,7 +226,7 @@ write(DynamicBuffer& db, frame_header const& fh)
 //
 template<class Buffers>
 void
-read(ping_data& data, Buffers const& bs)
+read_ping(ping_data& data, Buffers const& bs)
 {
     using boost::asio::buffer_copy;
     using boost::asio::buffer_size;
@@ -242,7 +242,7 @@ read(ping_data& data, Buffers const& bs)
 //
 template<class Buffers>
 void
-read(close_reason& cr,
+read_close(close_reason& cr,
     Buffers const& bs, close_code& code)
 {
     using boost::asio::buffer;
@@ -279,7 +279,7 @@ read(close_reason& cr,
     {
         cr.reason.resize(n);
         buffer_copy(buffer(&cr.reason[0], n), cb);
-        if(! detail::check_utf8(
+        if(! check_utf8(
             cr.reason.data(), cr.reason.size()))
         {
             code = close_code::protocol_error;

--- a/include/beast/websocket/detail/utf8_checker.hpp
+++ b/include/beast/websocket/detail/utf8_checker.hpp
@@ -18,51 +18,6 @@ namespace beast {
 namespace websocket {
 namespace detail {
 
-/*  This is a modified work.
-
-    Original version and license:
-        https://www.cl.cam.ac.uk/~mgk25/ucs/utf8_check.c
-    Permission is hereby granted, free of charge, to any person obtaining
-    a copy of this software and associated documentation files (the
-    "Software"), to deal in the Software without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Software, and to
-    permit persons to whom the Software is furnished to do so, subject
-    to the following conditions:
-
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-    ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. *
-
-    Additional changes:
-        Optimized for predominantly 7-bit content, 2016
-        https://github.com/uWebSockets/uWebSockets/blob/755bd362649c06abff102f18e273c5792c51c1a0/src/WebSocketProtocol.h#L198
-    Copyright (c) 2016 Alex Hultman and contributors
-
-    This software is provided 'as-is', without any express or implied
-    warranty. In no event will the authors be held liable for any damages
-    arising from the use of this software.
-
-    Permission is granted to anyone to use this software for any purpose,
-    including commercial applications, and to alter it and redistribute it
-    freely, subject to the following restrictions:
-
-    1. The origin of this software must not be misrepresented; you must not
-       claim that you wrote the original software. If you use this software
-       in a product, an acknowledgement in the product documentation would be
-       appreciated but is not required.
-    2. Altered source versions must be plainly marked as such, and must not be
-       misrepresented as being the original software.
-    3. This notice may not be removed or altered from any source distribution.
-*/
-
 /** A UTF8 validator.
 
     This validator can be used to check if a buffer containing UTF8 text is

--- a/include/beast/websocket/error.hpp
+++ b/include/beast/websocket/error.hpp
@@ -24,7 +24,10 @@ enum class error
     failed,
 
     /// Upgrade handshake failed
-    handshake_failed
+    handshake_failed,
+
+    /// buffer overflow
+    buffer_overflow
 };
 
 } // websocket

--- a/include/beast/websocket/impl/accept.ipp
+++ b/include/beast/websocket/impl/accept.ipp
@@ -28,8 +28,6 @@
 namespace beast {
 namespace websocket {
 
-//------------------------------------------------------------------------------
-
 // Respond to an upgrade HTTP request
 template<class NextLayer>
 template<class Handler>

--- a/include/beast/websocket/impl/error.ipp
+++ b/include/beast/websocket/impl/error.ipp
@@ -39,6 +39,7 @@ public:
         case error::closed: return "WebSocket connection closed normally";
         case error::failed: return "WebSocket connection failed due to a protocol violation";
         case error::handshake_failed: return "WebSocket Upgrade handshake failed";
+        case error::buffer_overflow: return "buffer overflow";
 
         default:
             return "beast.websocket error";

--- a/include/beast/websocket/impl/fail.ipp
+++ b/include/beast/websocket/impl/fail.ipp
@@ -1,0 +1,233 @@
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BEAST_WEBSOCKET_IMPL_FAIL_IPP
+#define BEAST_WEBSOCKET_IMPL_FAIL_IPP
+
+#include <beast/websocket/teardown.hpp>
+#include <beast/core/bind_handler.hpp>
+#include <beast/core/handler_ptr.hpp>
+#include <beast/core/flat_static_buffer.hpp>
+#include <beast/core/detail/config.hpp>
+#include <boost/asio/handler_alloc_hook.hpp>
+#include <boost/asio/handler_continuation_hook.hpp>
+#include <boost/asio/handler_invoke_hook.hpp>
+#include <boost/assert.hpp>
+#include <boost/config.hpp>
+#include <boost/optional.hpp>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace beast {
+namespace websocket {
+
+// _Fail the WebSocket Connection_
+//
+template<class NextLayer>
+template<class Handler>
+class stream<NextLayer>::fail_op
+{
+    Handler h_;
+    stream<NextLayer>& ws_;
+    int step_ = 0;
+    bool dispatched_ = false;
+    fail_how how_;
+    token tok_;
+
+public:
+    fail_op(fail_op&&) = default;
+    fail_op(fail_op const&) = default;
+
+    // send close code, then teardown
+    template<class DeducedHandler>
+    fail_op(
+        DeducedHandler&& h,
+        stream<NextLayer>& ws,
+        close_code code)
+        : h_(std::forward<DeducedHandler>(h))
+        , ws_(ws)
+        , how_(fail_how::code)
+        , tok_(ws_.t_.unique())
+    {
+        ws_.rd_.fb.consume(ws_.rd_.fb.size());
+        ws_.template write_close<
+            flat_static_buffer_base>(
+                ws_.rd_.fb, code);
+    }
+
+    // maybe send frame in fb, then teardown
+    template<class DeducedHandler>
+    fail_op(
+        DeducedHandler&& h,
+        stream<NextLayer>& ws,
+        fail_how how)
+        : h_(std::forward<DeducedHandler>(h))
+        , ws_(ws)
+        , how_(how)
+        , tok_(ws_.t_.unique())
+    {
+    }
+
+    Handler&
+    handler()
+    {
+        return h_;
+    }
+
+    void operator()(error_code ec = {},
+        std::size_t bytes_transferred = 0);
+
+    friend
+    void* asio_handler_allocate(
+        std::size_t size, fail_op* op)
+    {
+        using boost::asio::asio_handler_allocate;
+        return asio_handler_allocate(
+            size, std::addressof(op->h_));
+    }
+
+    friend
+    void asio_handler_deallocate(
+        void* p, std::size_t size, fail_op* op)
+    {
+        using boost::asio::asio_handler_deallocate;
+        asio_handler_deallocate(
+            p, size, std::addressof(op->h_));
+    }
+
+    friend
+    bool asio_handler_is_continuation(fail_op* op)
+    {
+        using boost::asio::asio_handler_is_continuation;
+        return op->dispatched_ ||
+            asio_handler_is_continuation(
+                std::addressof(op->h_));
+    }
+
+    template<class Function>
+    friend
+    void asio_handler_invoke(Function&& f, fail_op* op)
+    {
+        using boost::asio::asio_handler_invoke;
+        asio_handler_invoke(f,
+            std::addressof(op->h_));
+    }
+};
+
+template<class NextLayer>
+template<class Handler>
+void
+stream<NextLayer>::
+fail_op<Handler>::
+operator()(error_code ec, std::size_t)
+{
+    enum
+    {
+        do_start        = 0,
+        do_resume       = 20,
+        do_teardown     = 40
+    };
+    switch(step_)
+    {
+    case do_start:
+        // Acquire write block
+        if(ws_.wr_block_)
+        {
+            // suspend
+            BOOST_ASSERT(ws_.wr_block_ != tok_);
+            step_ = do_resume;
+            ws_.rd_op_.save(std::move(*this));
+            return;
+        }
+        ws_.wr_block_ = tok_;
+        goto go_write;
+
+    case do_resume:
+        BOOST_ASSERT(! ws_.wr_block_);
+        ws_.wr_block_ = tok_;
+        step_ = do_resume + 1;
+        // We were invoked from a foreign context, so post
+        return ws_.get_io_service().post(std::move(*this));
+
+    case do_resume + 1:
+        BOOST_ASSERT(ws_.wr_block_ == tok_);
+        dispatched_ = true;
+    go_write:
+        BOOST_ASSERT(ws_.wr_block_ == tok_);
+        if(ws_.failed_)
+        {
+            ws_.wr_block_.reset();
+            ec = boost::asio::error::operation_aborted;
+            break;
+        }
+        if(how_ == fail_how::teardown)
+            goto go_teardown;
+        if(ws_.wr_close_)
+            goto go_teardown;
+        // send close frame
+        step_ = do_teardown;
+        ws_.wr_close_ = true;
+        return boost::asio::async_write(
+            ws_.stream_, ws_.rd_.fb.data(),
+                std::move(*this));
+
+    case do_teardown:
+        BOOST_ASSERT(ws_.wr_block_ == tok_);
+        dispatched_ = true;
+        ws_.failed_ = !!ec;
+        if(ws_.failed_)
+        {
+            ws_.wr_block_.reset();
+            break;
+        }
+    go_teardown:
+        BOOST_ASSERT(ws_.wr_block_ == tok_);
+        step_ = do_teardown + 1;
+        websocket_helpers::call_async_teardown(
+            ws_.next_layer(), std::move(*this));
+        return;
+
+    case do_teardown + 1:
+        BOOST_ASSERT(ws_.wr_block_ == tok_);
+        dispatched_ = true;
+        ws_.failed_ = true;
+        ws_.wr_block_.reset();
+        if(ec == boost::asio::error::eof)
+        {
+            // Rationale:
+            // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+            ec.assign(0, ec.category());
+        }
+        if(! ec)
+        {
+            switch(how_)
+            {
+            default:
+            case fail_how::code:
+            case fail_how::teardown:    ec = error::failed; break;
+            case fail_how::close:       ec = error::closed; break;
+            }
+        }
+        break;
+    }
+    // upcall
+    BOOST_ASSERT(ws_.wr_block_ != tok_);
+    ws_.close_op_.maybe_invoke() ||
+        ws_.ping_op_.maybe_invoke() ||
+        ws_.wr_op_.maybe_invoke();
+    if(! dispatched_)
+        ws_.stream_.get_io_service().post(
+            bind_handler(std::move(h_), ec));
+    else
+        h_(ec);
+}
+
+} // websocket
+} // beast
+
+#endif

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -6,7 +6,7 @@ HERE=$PWD
 
 # Override gcc version to $GCC_VER.
 # Put an appropriate symlink at the front of the path.
-mkdir -v $HOME/bin
+mkdir -pv $HOME/bin
 for g in gcc g++ gcov gcc-ar gcc-nm gcc-ranlib
 do
   test -x $( type -p ${g}-$GCC_VER )

--- a/test/core/bind_handler.cpp
+++ b/test/core/bind_handler.cpp
@@ -10,17 +10,20 @@
 
 #include <beast/core/detail/type_traits.hpp>
 #include <beast/unit_test/suite.hpp>
-#include <functional>
+#include <string>
 
 namespace beast {
 
 class bind_handler_test : public unit_test::suite
 {
 public:
+    template<class... Args>
     struct handler
     {
         void
-        operator()() const;
+        operator()(Args const&...) const
+        {
+        }
     };
 
 #if 0
@@ -28,7 +31,7 @@ public:
     void
     failStdBind()
     {
-        std::bind(bind_handler(handler{}));
+        std::bind(bind_handler(handler<>{}));
     }
 #endif
 
@@ -37,14 +40,27 @@ public:
     {
         BEAST_EXPECT(v == 42);
     }
+    
+    void
+    testPlaceholders()
+    {
+        namespace ph = std::placeholders;
+        
+        bind_handler(handler<>{})();
+        bind_handler(handler<int>{}, 1)();
+        bind_handler(handler<int, std::string>{}, 1, "hello")();
+        bind_handler(handler<int>{}, ph::_1)(1);
+        bind_handler(handler<int, std::string>{}, ph::_1, ph::_2)(1, "hello");
+    }
 
-    void run()
+    void
+    run() override
     {
         auto f = bind_handler(std::bind(
             &bind_handler_test::callback, this,
                 std::placeholders::_1), 42);
         f();
-        pass();
+        testPlaceholders();
     }
 };
 

--- a/test/websocket/doc_snippets.cpp
+++ b/test/websocket/doc_snippets.cpp
@@ -163,7 +163,7 @@ boost::asio::ip::tcp::socket sock{ios};
 //[ws_snippet_16
     multi_buffer buffer;
     for(;;)
-        if(ws.read_frame(buffer))
+        if(ws.read_some(buffer, 0))
             break;
     ws.binary(ws.got_binary());
     consuming_buffers<multi_buffer::const_buffers_type> cb{buffer.data()};
@@ -172,12 +172,12 @@ boost::asio::ip::tcp::socket sock{ios};
         using boost::asio::buffer_size;
         if(buffer_size(cb) > 512)
         {
-            ws.write_frame(false, buffer_prefix(512, cb));
+            ws.write_some(false, buffer_prefix(512, cb));
             cb.consume(512);
         }
         else
         {
-            ws.write_frame(true, cb);
+            ws.write_some(true, cb);
             break;
         }
     }

--- a/test/websocket/error.cpp
+++ b/test/websocket/error.cpp
@@ -37,6 +37,7 @@ public:
         check("beast.websocket", error::closed);
         check("beast.websocket", error::failed);
         check("beast.websocket", error::handshake_failed);
+        check("beast.websocket", error::buffer_overflow);
     }
 };
 

--- a/test/websocket/websocket_async_echo_server.hpp
+++ b/test/websocket/websocket_async_echo_server.hpp
@@ -10,6 +10,7 @@
 
 #include <beast/core/multi_buffer.hpp>
 #include <beast/websocket/stream.hpp>
+#include <boost/asio.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 #include <atomic>

--- a/test/wstest/main.cpp
+++ b/test/wstest/main.cpp
@@ -167,7 +167,7 @@ private:
     {
         std::geometric_distribution<std::size_t> dist{
             double(4) / boost::asio::buffer_size(tb_)};
-        ws_.async_write_frame(true,
+        ws_.async_write_some(true,
             beast::buffer_prefix(dist(rng_), tb_),
             alloc_.wrap(std::bind(
                 &connection::on_write,


### PR DESCRIPTION
* Tidy up buffer_front
* static_buffer::consume improvement
* multi_buffer is type-check friendly
* bind_handler allows placeholders
* Add consuming_buffers::get

WebSocket:

* WebSocket read optimization

API Changes:

* websocket::stream::read_buffer_size is removed

Actions Required:

* Remove calls websocket::stream::read_buffer_size
* Use read_some and write_some instead of read_frame and write_frame
